### PR TITLE
chore: update license headers and .NET version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=velvet-lab_xsdk&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=velvet-lab_xsdk)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=velvet-lab_xsdk&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=velvet-lab_xsdk)
 
-![.NET Version](https://img.shields.io/badge/.NET-9.0-512bd4?logo=dotnet)
+![.NET Version](https://img.shields.io/badge/.NET-10.0-512bd4?logo=dotnet)
 ![pnpm Version](https://img.shields.io/badge/pnpm-10.x-f69220?logo=pnpm)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-yellow.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ---
 
@@ -59,24 +59,24 @@ Key goals:
 
 | Category            | Technology                 | Version                      |
 |---------------------|----------------------------|------------------------------|
-| Runtime             | .NET                       | 8.0 / 9.0                    |
-| Language            | C#                         | 12 (latest)                  |
-| Web Framework       | ASP.NET Core               | 9.0                          |
-| ORM                 | Entity Framework Core      | 9.0.11                       |
-| Document DB         | MongoDB (EF Core provider) | 9.0.3                        |
+| Runtime             | .NET                       | 10.0                         |
+| Language            | C#                         | 13 (latest)                  |
+| Web Framework       | ASP.NET Core               | 10.0                         |
+| ORM                 | Entity Framework Core      | 10.0.5                       |
+| Document DB         | MongoDB (EF Core provider) | 10.0.1                       |
 | Embedded DB         | LiteDB / LiteDB.Async      | 5.0.21                       |
 | Flat File Store     | JsonFlatFileDataStore      | 2.4.2                        |
 | Secrets Management  | VaultSharp                 | 1.17.5.1                     |
 | Plugin System       | Weikio.PluginFramework     | 1.5.1                        |
 | Validation          | FluentValidation           | 12.1.1                       |
 | Object Mapping      | Mapster                    | 7.4.0                        |
-| Logging             | NLog                       | 6.0.6                        |
-| Observability       | OpenTelemetry              | 1.9.0 (net8) / 1.14.0 (net9) |
-| API Versioning      | Asp.Versioning             | 8.1.0                        |
-| API Documentation   | Swashbuckle (OpenAPI)      | 9.0.6                        |
+| Logging             | NLog                       | 6.1.1                        |
+| Observability       | OpenTelemetry              | 1.15.0                       |
+| API Versioning      | Asp.Versioning             | 8.1.1                        |
+| API Documentation   | Microsoft.AspNetCore.OpenAPI | 10.0.5                     |
 | Cloud Events        | CloudNative.CloudEvents    | 2.8.0                        |
 | CLI                 | Spectre.Console.Cli        | 0.53.1                       |
-| HTTP Client         | RestSharp                  | 113.0.0                      |
+| HTTP Client         | RestSharp                  | 114.0.0                      |
 | Security Middleware | NWebsec                    | 3.0.0                        |
 | Release Tooling     | semantic-release / pnpm    | —                            |
 
@@ -128,7 +128,7 @@ xSDK follows a **modular, layered architecture** where each library is independe
 
 ### Prerequisites
 
-- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8) or [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9) (version `8.0.411` or later, see `global.json`)
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10) (version `10.0.200` or later, see `global.json`)
 - [just](https://just.systems/) (command runner for development tasks)
 - [pnpm](https://pnpm.io/) 10.x (required for release tooling only)
 - [Git](https://git-scm.com/)
@@ -173,12 +173,17 @@ dotnet add package xSdk.Extensions.AspNetCore
 ### Minimal Host Setup
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using xSdk.Hosting;
 
-var host = await SlimHost.CreateAsync(args, builder =>
-{
-    builder.Services.AddMyService();
-});
+var host = Host
+    .CreateBuilder(args, "my-app", "my-company", "ma")
+    .ConfigureServices((context, services) =>
+    {
+        services.AddMyService();
+    })
+    .Build();
 
 await host.RunAsync();
 ```
@@ -257,7 +262,7 @@ libs/xSdk.SomeLibrary/
 
 - API versioning configuration
 - Problem Details middleware integration
-- FluentValidation-to-Swagger bridge via `MicroElements.Swashbuckle.FluentValidation`
+- FluentValidation DI registration
 - NWebsec security headers middleware
 - API key authentication support
 
@@ -375,7 +380,6 @@ Testing follows the guidelines in [.github/instructions/testing.instructions.md]
 | Library                                  | Purpose                                                |
 |------------------------------------------|--------------------------------------------------------|
 | xUnit                                    | Test runner (`[Fact]`, `[Theory]`)                     |
-| FluentAssertions                         | Expressive assertions                                  |
 | Moq                                      | Mocking framework                                      |
 | Testcontainers                           | Integration tests with real containers (MongoDB, etc.) |
 | `Xunit.SkippableFact`                    | Skip tests conditionally                               |
@@ -469,6 +473,6 @@ To report a vulnerability, use [GitHub's private vulnerability reporting](https:
 
 ## License
 
-This project is licensed under the **MIT License** — see the [LICENSE](LICENSE) file for details.
+This project is licensed under the **Apache-2.0 License** — see the [LICENSE](LICENSE) file for details.
 
 Copyright © 2026 [Velvet Lab](https://github.com/velvet-lab)

--- a/demos/Directory.Build.props
+++ b/demos/Directory.Build.props
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2026 Roland Breitschaft
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />

--- a/demos/Directory.Build.targets
+++ b/demos/Directory.Build.targets
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2026 Roland Breitschaft
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />

--- a/demos/console/host/Program.cs
+++ b/demos/console/host/Program.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NLog;

--- a/demos/datalayer-entityframework/host/Data/ISampleRepository.cs
+++ b/demos/datalayer-entityframework/host/Data/ISampleRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-entityframework/host/Data/ISecondSampleRepository.cs
+++ b/demos/datalayer-entityframework/host/Data/ISecondSampleRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/demos/datalayer-entityframework/host/Data/SampleDbContext.cs
+++ b/demos/datalayer-entityframework/host/Data/SampleDbContext.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 

--- a/demos/datalayer-entityframework/host/Data/SampleEntity.cs
+++ b/demos/datalayer-entityframework/host/Data/SampleEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations.Schema;
 using xSdk.Data;
 

--- a/demos/datalayer-entityframework/host/Data/SampleMappingProfile.cs
+++ b/demos/datalayer-entityframework/host/Data/SampleMappingProfile.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 
 
 using xSdk.Data;

--- a/demos/datalayer-entityframework/host/Data/SampleModel.cs
+++ b/demos/datalayer-entityframework/host/Data/SampleModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-entityframework/host/Data/SampleRepository.cs
+++ b/demos/datalayer-entityframework/host/Data/SampleRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-entityframework/host/Data/SecondDbContext.cs
+++ b/demos/datalayer-entityframework/host/Data/SecondDbContext.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 

--- a/demos/datalayer-entityframework/host/Data/SecondEntity.cs
+++ b/demos/datalayer-entityframework/host/Data/SecondEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;

--- a/demos/datalayer-entityframework/host/Data/SecondSampleRepository.cs
+++ b/demos/datalayer-entityframework/host/Data/SecondSampleRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-entityframework/host/DbProviderNames.cs
+++ b/demos/datalayer-entityframework/host/DbProviderNames.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/demos/datalayer-entityframework/host/Hosting/MyDataHost.cs
+++ b/demos/datalayer-entityframework/host/Hosting/MyDataHost.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;

--- a/demos/datalayer-entityframework/host/Program.cs
+++ b/demos/datalayer-entityframework/host/Program.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;

--- a/demos/datalayer-flatfile/host/Data/ISampleRepository.cs
+++ b/demos/datalayer-flatfile/host/Data/ISampleRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-flatfile/host/Data/SampleEntity.cs
+++ b/demos/datalayer-flatfile/host/Data/SampleEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations.Schema;
 using xSdk.Data;
 

--- a/demos/datalayer-flatfile/host/Data/SampleEntityFakes.cs
+++ b/demos/datalayer-flatfile/host/Data/SampleEntityFakes.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Bogus;
 using xSdk.Data;
 

--- a/demos/datalayer-flatfile/host/Data/SampleMappingProfile.cs
+++ b/demos/datalayer-flatfile/host/Data/SampleMappingProfile.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-flatfile/host/Data/SampleModel.cs
+++ b/demos/datalayer-flatfile/host/Data/SampleModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-flatfile/host/Data/SampleRepository.cs
+++ b/demos/datalayer-flatfile/host/Data/SampleRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-flatfile/host/Hosting/MyDataHost.cs
+++ b/demos/datalayer-flatfile/host/Hosting/MyDataHost.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;

--- a/demos/datalayer-flatfile/host/Program.cs
+++ b/demos/datalayer-flatfile/host/Program.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NLog;

--- a/demos/datalayer-mongodb/host/Data/ISampleRepository.cs
+++ b/demos/datalayer-mongodb/host/Data/ISampleRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-mongodb/host/Data/SampleDbContext.cs
+++ b/demos/datalayer-mongodb/host/Data/SampleDbContext.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using xSdk.Data;

--- a/demos/datalayer-mongodb/host/Data/SampleEntity.cs
+++ b/demos/datalayer-mongodb/host/Data/SampleEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations.Schema;
 using xSdk.Data;
 

--- a/demos/datalayer-mongodb/host/Data/SampleMappingProfile.cs
+++ b/demos/datalayer-mongodb/host/Data/SampleMappingProfile.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 using xSdk.Data.Converters.Mapper;
 

--- a/demos/datalayer-mongodb/host/Data/SampleModel.cs
+++ b/demos/datalayer-mongodb/host/Data/SampleModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-mongodb/host/Data/SampleRepository.cs
+++ b/demos/datalayer-mongodb/host/Data/SampleRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-mongodb/host/Hosting/MyDataHost.cs
+++ b/demos/datalayer-mongodb/host/Hosting/MyDataHost.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/demos/datalayer-mongodb/host/Program.cs
+++ b/demos/datalayer-mongodb/host/Program.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DotNet.Testcontainers.Builders;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;

--- a/demos/datalayer-nosql/host/Data/ISampleRepository.cs
+++ b/demos/datalayer-nosql/host/Data/ISampleRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-nosql/host/Data/SampleEntity.cs
+++ b/demos/datalayer-nosql/host/Data/SampleEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations.Schema;
 using xSdk.Data;
 

--- a/demos/datalayer-nosql/host/Data/SampleEntityFakes.cs
+++ b/demos/datalayer-nosql/host/Data/SampleEntityFakes.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Bogus;
 using xSdk.Data;
 

--- a/demos/datalayer-nosql/host/Data/SampleMappingProfile.cs
+++ b/demos/datalayer-nosql/host/Data/SampleMappingProfile.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-nosql/host/Data/SampleModel.cs
+++ b/demos/datalayer-nosql/host/Data/SampleModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-nosql/host/Data/SampleRepository.cs
+++ b/demos/datalayer-nosql/host/Data/SampleRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/datalayer-nosql/host/Hosting/MyDataHost.cs
+++ b/demos/datalayer-nosql/host/Hosting/MyDataHost.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;

--- a/demos/datalayer-nosql/host/Program.cs
+++ b/demos/datalayer-nosql/host/Program.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NLog;

--- a/demos/datalayer-vault/host/Hosting/MyDataHost.cs
+++ b/demos/datalayer-vault/host/Hosting/MyDataHost.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using xSdk.Data;

--- a/demos/datalayer-vault/host/Program.cs
+++ b/demos/datalayer-vault/host/Program.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Before you can use the Datalayer you have to create a AppRole Auth Method and a Role
 //
 // Enable Auth Method

--- a/demos/host/host/Program.cs
+++ b/demos/host/host/Program.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NLog;

--- a/demos/plugin/host/Program.cs
+++ b/demos/plugin/host/Program.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using NLog;
 using xSdk.Demos;

--- a/demos/plugin/plugin/MyPlugin.cs
+++ b/demos/plugin/plugin/MyPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Hosting;
 

--- a/demos/plugin/plugin/PluginHost.cs
+++ b/demos/plugin/plugin/PluginHost.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 

--- a/demos/shared/lib/Data/ISampleEntity.cs
+++ b/demos/shared/lib/Data/ISampleEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Demos.Data;
 
 public interface ISampleEntity

--- a/demos/shared/lib/Hosting/MyCustomHost.cs
+++ b/demos/shared/lib/Hosting/MyCustomHost.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using xSdk.Extensions.Variable;

--- a/demos/shared/lib/SetupWithPrefix.cs
+++ b/demos/shared/lib/SetupWithPrefix.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 using xSdk.Extensions.Variable.Attributes;
 

--- a/demos/shared/lib/SetupWithoutPrefix.cs
+++ b/demos/shared/lib/SetupWithoutPrefix.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 using xSdk.Extensions.Variable.Attributes;
 

--- a/demos/telemetry/host/LocalService.cs
+++ b/demos/telemetry/host/LocalService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Logging;

--- a/demos/telemetry/host/MyHost.cs
+++ b/demos/telemetry/host/MyHost.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 

--- a/demos/telemetry/host/Program.cs
+++ b/demos/telemetry/host/Program.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NLog;

--- a/demos/webapi/host/Builders/ApiKeyHandler.cs
+++ b/demos/webapi/host/Builders/ApiKeyHandler.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.ObjectModel;
 using System.Security.Claims;
 using AspNetCore.Authentication.ApiKey;

--- a/demos/webapi/host/Builders/ApiKeyHandlerTwo.cs
+++ b/demos/webapi/host/Builders/ApiKeyHandlerTwo.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.ObjectModel;
 using System.Security.Claims;
 using AspNetCore.Authentication.ApiKey;

--- a/demos/webapi/host/Builders/AuthenticationPluginBuilder.cs
+++ b/demos/webapi/host/Builders/AuthenticationPluginBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;

--- a/demos/webapi/host/Builders/DataProtectionPluginBuilder.cs
+++ b/demos/webapi/host/Builders/DataProtectionPluginBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.DataProtection;
 using xSdk.Extensions.Plugin;
 using xSdk.Plugins.DataProtection;

--- a/demos/webapi/host/Builders/DocumentationPluginBuilder.cs
+++ b/demos/webapi/host/Builders/DocumentationPluginBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Asp.Versioning.ApiExplorer;
 using Microsoft.OpenApi;
 using xSdk.Extensions.Plugin;

--- a/demos/webapi/host/Builders/LinksPluginBuilder.cs
+++ b/demos/webapi/host/Builders/LinksPluginBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Demos.Controllers.v3;
 using xSdk.Demos.Data;
 using xSdk.Extensions.Links;

--- a/demos/webapi/host/Builders/MyClaimTypes.cs
+++ b/demos/webapi/host/Builders/MyClaimTypes.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Security.Claims;
 
 namespace xSdk.Demos.Builders;

--- a/demos/webapi/host/Builders/MyClaimValues.cs
+++ b/demos/webapi/host/Builders/MyClaimValues.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Demos.Builders;
 
 internal static class MyClaimValues

--- a/demos/webapi/host/Controllers/SampleController.cs
+++ b/demos/webapi/host/Controllers/SampleController.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;

--- a/demos/webapi/host/Controllers/v2/SampleController.cs
+++ b/demos/webapi/host/Controllers/v2/SampleController.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;

--- a/demos/webapi/host/Controllers/v3/SampleController.cs
+++ b/demos/webapi/host/Controllers/v3/SampleController.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Asp.Versioning;
 using FluentValidation;
 using Microsoft.AspNetCore.Authorization;

--- a/demos/webapi/host/Data/SampleDatabase.cs
+++ b/demos/webapi/host/Data/SampleDatabase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Demos.Data;

--- a/demos/webapi/host/Data/SampleModel.cs
+++ b/demos/webapi/host/Data/SampleModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel;
 using xSdk.Data;
 

--- a/demos/webapi/host/Data/SampleModelExamples.cs
+++ b/demos/webapi/host/Data/SampleModelExamples.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Bogus;
 using xSdk.Data;
 

--- a/demos/webapi/host/Data/SampleModelValidator.cs
+++ b/demos/webapi/host/Data/SampleModelValidator.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using FluentValidation;
 
 namespace xSdk.Demos.Data;

--- a/demos/webapi/host/Program.cs
+++ b/demos/webapi/host/Program.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Hosting;

--- a/libs/xSdk.Data.EntityFramework.MongoDB/src/Converters/Mapper/ExtensionDataConverter.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/src/Converters/Mapper/ExtensionDataConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 
 namespace xSdk.Data.Converters.Mapper;

--- a/libs/xSdk.Data.EntityFramework.MongoDB/src/Converters/Mapper/ObjectIdConverter.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/src/Converters/Mapper/ObjectIdConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using MongoDB.Bson;
 
 namespace xSdk.Data.Converters.Mapper;

--- a/libs/xSdk.Data.EntityFramework.MongoDB/src/MongoDbContext.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/src/MongoDbContext.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 

--- a/libs/xSdk.Data.EntityFramework.MongoDB/src/MongoDbEntity.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/src/MongoDbEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;

--- a/libs/xSdk.Data.EntityFramework.MongoDB/src/MongoDbEntityPK.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/src/MongoDbEntityPK.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using MongoDB.Bson;
 using xSdk.Data.Converters.Mapper;
 

--- a/libs/xSdk.Data.EntityFramework.MongoDB/src/MongoDbModel.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/src/MongoDbModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public class MongoDbModel : Model, IModel<MongoDbModelPK, string>

--- a/libs/xSdk.Data.EntityFramework.MongoDB/src/MongoDbModelPK.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/src/MongoDbModelPK.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using MongoDB.Bson;
 using xSdk.Data.Converters.Mapper;
 

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/Converters/Mapper/ExtensionDataConverterTests.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/Converters/Mapper/ExtensionDataConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/Globals.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/Globals.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 internal static class Globals

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/InsertDataTests.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/InsertDataTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/MappingTests.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/MappingTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using MongoDB.Bson;
 using xSdk.Data.Mocks;
 

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/DatabaseFixture.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/DatabaseFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DotNet.Testcontainers.Builders;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/ITestRepository.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/ITestRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal interface ITestRepository : IRepository

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/TestDbContext.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/TestDbContext.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/TestEntity.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/TestEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class TestEntity : MongoDbEntity

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/TestEntityFakes.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/TestEntityFakes.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Bogus;
 using MongoDB.Bson;
 

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/TestMappingProfile.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/TestMappingProfile.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Converters.Mapper;
 
 namespace xSdk.Data.Mocks;

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/TestModel.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/TestModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class TestModel : MongoDbModel

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/TestRepository.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/Mocks/TestRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class TestRepository : EntityFrameworkRepository<TestDbContext, TestEntity>, ITestRepository

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/MongoDbEntityPKTests.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/MongoDbEntityPKTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using MongoDB.Bson;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/MongoDbEntityTests.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/MongoDbEntityTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using MongoDB.Bson;
 using xSdk.Data.Mocks;
 

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/MongoDbModelPKTests.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/MongoDbModelPKTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using MongoDB.Bson;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.EntityFramework.MongoDB/tests/MongoDbModelTests.cs
+++ b/libs/xSdk.Data.EntityFramework.MongoDB/tests/MongoDbModelTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using MongoDB.Bson;
 using xSdk.Data.Mocks;
 

--- a/libs/xSdk.Data.EntityFramework/src/EFEntity.cs
+++ b/libs/xSdk.Data.EntityFramework/src/EFEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;

--- a/libs/xSdk.Data.EntityFramework/src/EFModel.cs
+++ b/libs/xSdk.Data.EntityFramework/src/EFModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public abstract class EFModel : Model, IModel<GuidStringPK, string>

--- a/libs/xSdk.Data.EntityFramework/src/EntityFrameworkConnectionBuilder.cs
+++ b/libs/xSdk.Data.EntityFramework/src/EntityFrameworkConnectionBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 internal sealed class EntityFrameworkConnectionBuilder : ConnectionBuilder

--- a/libs/xSdk.Data.EntityFramework/src/EntityFrameworkDatabase.cs
+++ b/libs/xSdk.Data.EntityFramework/src/EntityFrameworkDatabase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.EntityFrameworkCore;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.EntityFramework/src/EntityFrameworkDatabaseSetup.cs
+++ b/libs/xSdk.Data.EntityFramework/src/EntityFrameworkDatabaseSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public class EntityFrameworkDatabaseSetup : DatabaseSetup

--- a/libs/xSdk.Data.EntityFramework/src/EntityFrameworkRepository.cs
+++ b/libs/xSdk.Data.EntityFramework/src/EntityFrameworkRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;

--- a/libs/xSdk.Data.EntityFramework/src/IRepository.cs
+++ b/libs/xSdk.Data.EntityFramework/src/IRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.EntityFrameworkCore;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.EntityFramework/src/ServiceCollectionExtensions.cs
+++ b/libs/xSdk.Data.EntityFramework/src/ServiceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.EntityFrameworkCore;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.EntityFramework/tests/ConcurrentDbContextTests.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/ConcurrentDbContextTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/libs/xSdk.Data.EntityFramework/tests/CrudDataTests.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/CrudDataTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.EntityFramework/tests/EFDatabaseSetupTests.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/EFDatabaseSetupTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public class EFDatabaseSetupTests

--- a/libs/xSdk.Data.EntityFramework/tests/EFEntityTests.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/EFEntityTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.EntityFramework/tests/EFModelTests.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/EFModelTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.EntityFramework/tests/Globals.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Globals.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.EntityFramework/tests/InitDatalayerTests.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/InitDatalayerTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.EntityFramework/tests/InsertDataTests.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/InsertDataTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.EntityFramework/tests/Mocks/ConcurrentEntityOne.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Mocks/ConcurrentEntityOne.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class ConcurrentEntityOne : EFEntity

--- a/libs/xSdk.Data.EntityFramework/tests/Mocks/ConcurrentEntityTwo.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Mocks/ConcurrentEntityTwo.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class ConcurrentEntityTwo : EFEntity

--- a/libs/xSdk.Data.EntityFramework/tests/Mocks/ConcurrentRepositoryOne.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Mocks/ConcurrentRepositoryOne.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class ConcurrentRepositoryOne : EntityFrameworkRepository<TestDbContext, ConcurrentEntityOne>, IConcurrentRepositoryOne

--- a/libs/xSdk.Data.EntityFramework/tests/Mocks/ConcurrentRepositoryTwo.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Mocks/ConcurrentRepositoryTwo.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/libs/xSdk.Data.EntityFramework/tests/Mocks/CrudDatabaseFixture.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Mocks/CrudDatabaseFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;

--- a/libs/xSdk.Data.EntityFramework/tests/Mocks/DatabaseFixture.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Mocks/DatabaseFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;

--- a/libs/xSdk.Data.EntityFramework/tests/Mocks/IConcurrentRepositoryOne.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Mocks/IConcurrentRepositoryOne.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal interface IConcurrentRepositoryOne : IRepository

--- a/libs/xSdk.Data.EntityFramework/tests/Mocks/IConcurrentRepositoryTwo.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Mocks/IConcurrentRepositoryTwo.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/libs/xSdk.Data.EntityFramework/tests/Mocks/ITestRepository.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Mocks/ITestRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal interface ITestRepository : IRepository

--- a/libs/xSdk.Data.EntityFramework/tests/Mocks/TestDbContext.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Mocks/TestDbContext.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 

--- a/libs/xSdk.Data.EntityFramework/tests/Mocks/TestEntity.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Mocks/TestEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class TestEntity : EFEntity

--- a/libs/xSdk.Data.EntityFramework/tests/Mocks/TestModel.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Mocks/TestModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class TestModel : EFModel

--- a/libs/xSdk.Data.EntityFramework/tests/Mocks/TestRepository.cs
+++ b/libs/xSdk.Data.EntityFramework/tests/Mocks/TestRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class TestRepository : EntityFrameworkRepository<TestDbContext, TestEntity>, ITestRepository

--- a/libs/xSdk.Data.FlatFile/src/FlatFileConnectionBuilder.cs
+++ b/libs/xSdk.Data.FlatFile/src/FlatFileConnectionBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Logging;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.FlatFile/src/FlatFileDatabase.cs
+++ b/libs/xSdk.Data.FlatFile/src/FlatFileDatabase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using JsonFlatFileDataStore;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.FlatFile/src/FlatFileDatabaseSetup.cs
+++ b/libs/xSdk.Data.FlatFile/src/FlatFileDatabaseSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.FlatFile/src/FlatFileEntity.cs
+++ b/libs/xSdk.Data.FlatFile/src/FlatFileEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;

--- a/libs/xSdk.Data.FlatFile/src/FlatFileModel.cs
+++ b/libs/xSdk.Data.FlatFile/src/FlatFileModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public abstract class FlatFileModel : Model, IModel<GuidStringPK, string>

--- a/libs/xSdk.Data.FlatFile/src/FlatFileRepository.cs
+++ b/libs/xSdk.Data.FlatFile/src/FlatFileRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Linq.Expressions;
 using JsonFlatFileDataStore;
 

--- a/libs/xSdk.Data.FlatFile/src/IFlatFileDatabaseSetup.cs
+++ b/libs/xSdk.Data.FlatFile/src/IFlatFileDatabaseSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public interface IFlatFileDatabaseSetup

--- a/libs/xSdk.Data.FlatFile/src/ServiceCollectionExtensions.cs
+++ b/libs/xSdk.Data.FlatFile/src/ServiceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public static class ServiceCollectionExtensions

--- a/libs/xSdk.Data.FlatFile/tests/FlatFileDatabaseSetupTests.cs
+++ b/libs/xSdk.Data.FlatFile/tests/FlatFileDatabaseSetupTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public class FlatFileDatabaseSetupTests

--- a/libs/xSdk.Data.FlatFile/tests/FlatFileEntityTests.cs
+++ b/libs/xSdk.Data.FlatFile/tests/FlatFileEntityTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public class FlatFileEntityTests

--- a/libs/xSdk.Data.FlatFile/tests/Globals.cs
+++ b/libs/xSdk.Data.FlatFile/tests/Globals.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 internal static class Globals

--- a/libs/xSdk.Data.FlatFile/tests/Mocks/DatabaseFixture.cs
+++ b/libs/xSdk.Data.FlatFile/tests/Mocks/DatabaseFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Images;

--- a/libs/xSdk.Data.FlatFile/tests/Mocks/ITestRepository.cs
+++ b/libs/xSdk.Data.FlatFile/tests/Mocks/ITestRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal interface ITestRepository : IRepository

--- a/libs/xSdk.Data.FlatFile/tests/Mocks/TestEntity.cs
+++ b/libs/xSdk.Data.FlatFile/tests/Mocks/TestEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class TestEntity : FlatFileEntity

--- a/libs/xSdk.Data.FlatFile/tests/Mocks/TestEntityFakes.cs
+++ b/libs/xSdk.Data.FlatFile/tests/Mocks/TestEntityFakes.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Bogus;
 
 namespace xSdk.Data.Mocks;

--- a/libs/xSdk.Data.FlatFile/tests/Mocks/TestMapper.cs
+++ b/libs/xSdk.Data.FlatFile/tests/Mocks/TestMapper.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //using xSdk.Data.Converters.Mapper;
 
 //namespace xSdk.Data.Mocks

--- a/libs/xSdk.Data.FlatFile/tests/Mocks/TestModel.cs
+++ b/libs/xSdk.Data.FlatFile/tests/Mocks/TestModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class TestModel : FlatFileModel

--- a/libs/xSdk.Data.FlatFile/tests/Mocks/TestRepository.cs
+++ b/libs/xSdk.Data.FlatFile/tests/Mocks/TestRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class TestRepository : FlatFileRepository<TestEntity>, ITestRepository

--- a/libs/xSdk.Data.FlatFile/tests/UnitTest1.cs
+++ b/libs/xSdk.Data.FlatFile/tests/UnitTest1.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public class FlatFileModelTests

--- a/libs/xSdk.Data.NoSql/src/Data/Converters/Bson/BsonConverter.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/Converters/Bson/BsonConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 
 namespace xSdk.Data.Converters.Bson;

--- a/libs/xSdk.Data.NoSql/src/Data/Converters/Bson/BsonValueConverter.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/Converters/Bson/BsonValueConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 
 namespace xSdk.Data.Converters.Bson;

--- a/libs/xSdk.Data.NoSql/src/Data/Converters/Mapper/ObjectIdConverter.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/Converters/Mapper/ObjectIdConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 
 namespace xSdk.Data.Converters.Mapper;

--- a/libs/xSdk.Data.NoSql/src/Data/IDatalayerBuilderExtensions.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/IDatalayerBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public static class IDatalayerBuilderExtensions

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlConnectionBuilder.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlConnectionBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlDatabase.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlDatabase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 using LiteDB.Async;
 using Microsoft.Extensions.Logging;

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlDatabaseSetup.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlDatabaseSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Globalization;
 using LiteDB;
 using xSdk.Extensions.Variable;

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlEntity.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlEntityPK.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlEntityPK.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 using xSdk.Data.Converters.Mapper;
 

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlFieldAttribute.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlFieldAttribute.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlIgnoreAttribute.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlIgnoreAttribute.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlIndex.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlIndex.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 internal sealed class NoSqlIndex

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlIndexAttribute.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlIndexAttribute.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlIndexExtensions.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlIndexExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlModel.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public abstract class NoSqlModel : Model, IModel<NoSqlModelPK, string>

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlModelPK.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlModelPK.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 using xSdk.Data.Converters.Mapper;
 

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Execute.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Execute.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 using xSdk.Data.Converters.Bson;
 

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Insert.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Insert.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public partial class NoSqlRepository<TEntity>

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Records.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Records.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public partial class NoSqlRepository<TEntity>

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Remove.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Remove.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Linq.Expressions;
 using LiteDB;
 using xSdk.Data.Converters.Bson;

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Select.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Select.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Linq.Expressions;
 using LiteDB;
 using xSdk.Data.Converters.Bson;

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Update.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Update.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public partial class NoSqlRepository<TEntity>

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Upsert.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.Upsert.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Converters.Bson;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.cs
+++ b/libs/xSdk.Data.NoSql/src/Data/NoSqlRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB.Async;
 using NLog;
 

--- a/libs/xSdk.Data.NoSql/src/Extensions/Configuration/NoSqlConfigurationProvider.cs
+++ b/libs/xSdk.Data.NoSql/src/Extensions/Configuration/NoSqlConfigurationProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 
 namespace xSdk.Extensions.Configuration;

--- a/libs/xSdk.Data.NoSql/src/Extensions/Configuration/NoSqlConfigurationSource.cs
+++ b/libs/xSdk.Data.NoSql/src/Extensions/Configuration/NoSqlConfigurationSource.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 using Microsoft.Extensions.Configuration;
 

--- a/libs/xSdk.Data.NoSql/src/Extensions/Configuration/ServiceCollectionExtensions.cs
+++ b/libs/xSdk.Data.NoSql/src/Extensions/Configuration/ServiceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 using Microsoft.Extensions.Configuration;
 

--- a/libs/xSdk.Data.NoSql/tests/Converters/BsonConvertersTests.cs
+++ b/libs/xSdk.Data.NoSql/tests/Converters/BsonConvertersTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 using xSdk.Data.Converters.Bson;
 using xSdk.Data.Converters.Mapper;

--- a/libs/xSdk.Data.NoSql/tests/Globals.cs
+++ b/libs/xSdk.Data.NoSql/tests/Globals.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 internal static class Globals

--- a/libs/xSdk.Data.NoSql/tests/InsertDataTests.cs
+++ b/libs/xSdk.Data.NoSql/tests/InsertDataTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.NoSql/tests/MappingTests.cs
+++ b/libs/xSdk.Data.NoSql/tests/MappingTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 using xSdk.Data.Mocks;
 

--- a/libs/xSdk.Data.NoSql/tests/Mocks/DatabaseFixture.cs
+++ b/libs/xSdk.Data.NoSql/tests/Mocks/DatabaseFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Images;

--- a/libs/xSdk.Data.NoSql/tests/Mocks/ITestRepository.cs
+++ b/libs/xSdk.Data.NoSql/tests/Mocks/ITestRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal interface ITestRepository : IRepository

--- a/libs/xSdk.Data.NoSql/tests/Mocks/TestEntity.cs
+++ b/libs/xSdk.Data.NoSql/tests/Mocks/TestEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class TestEntity : NoSqlEntity

--- a/libs/xSdk.Data.NoSql/tests/Mocks/TestEntityFakes.cs
+++ b/libs/xSdk.Data.NoSql/tests/Mocks/TestEntityFakes.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Bogus;
 using LiteDB;
 

--- a/libs/xSdk.Data.NoSql/tests/Mocks/TestMappingProfile.cs
+++ b/libs/xSdk.Data.NoSql/tests/Mocks/TestMappingProfile.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Converters.Mapper;
 
 namespace xSdk.Data.Mocks;

--- a/libs/xSdk.Data.NoSql/tests/Mocks/TestModel.cs
+++ b/libs/xSdk.Data.NoSql/tests/Mocks/TestModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class TestModel : NoSqlModel

--- a/libs/xSdk.Data.NoSql/tests/Mocks/TestRepository.cs
+++ b/libs/xSdk.Data.NoSql/tests/Mocks/TestRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class TestRepository : NoSqlRepository<TestEntity>, ITestRepository

--- a/libs/xSdk.Data.NoSql/tests/NoSqlAttributeTests.cs
+++ b/libs/xSdk.Data.NoSql/tests/NoSqlAttributeTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public class NoSqlAttributeTests

--- a/libs/xSdk.Data.NoSql/tests/NoSqlDatabaseSetupTests.cs
+++ b/libs/xSdk.Data.NoSql/tests/NoSqlDatabaseSetupTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Globalization;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.NoSql/tests/NoSqlEntityPKTests.cs
+++ b/libs/xSdk.Data.NoSql/tests/NoSqlEntityPKTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.NoSql/tests/NoSqlEntityTests.cs
+++ b/libs/xSdk.Data.NoSql/tests/NoSqlEntityTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 using xSdk.Data.Mocks;
 

--- a/libs/xSdk.Data.NoSql/tests/NoSqlModelPKTests.cs
+++ b/libs/xSdk.Data.NoSql/tests/NoSqlModelPKTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.NoSql/tests/NoSqlModelTests.cs
+++ b/libs/xSdk.Data.NoSql/tests/NoSqlModelTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using LiteDB;
 using xSdk.Data.Mocks;
 

--- a/libs/xSdk.Data.Vault/src/Data/AppRoleAuth.cs
+++ b/libs/xSdk.Data.Vault/src/Data/AppRoleAuth.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public sealed class AppRoleAuth

--- a/libs/xSdk.Data.Vault/src/Data/AppRoleAuthSetup.cs
+++ b/libs/xSdk.Data.Vault/src/Data/AppRoleAuthSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json.Serialization;
 using NLog;
 using xSdk.Extensions.Variable;

--- a/libs/xSdk.Data.Vault/src/Data/CertAuth.cs
+++ b/libs/xSdk.Data.Vault/src/Data/CertAuth.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Cryptography.X509Certificates;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.Vault/src/Data/CertAuthSetup.cs
+++ b/libs/xSdk.Data.Vault/src/Data/CertAuthSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json.Serialization;
 using NLog;

--- a/libs/xSdk.Data.Vault/src/Data/DatalayerBuilderExtensions.cs
+++ b/libs/xSdk.Data.Vault/src/Data/DatalayerBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public static class DatalayerBuilderExtensions

--- a/libs/xSdk.Data.Vault/src/Data/IReadOnlyVaultRepository.cs
+++ b/libs/xSdk.Data.Vault/src/Data/IReadOnlyVaultRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public interface IReadOnlyVaultRepository : IRepository

--- a/libs/xSdk.Data.Vault/src/Data/IVaultRepository.cs
+++ b/libs/xSdk.Data.Vault/src/Data/IVaultRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public interface IVaultRepository : IReadOnlyVaultRepository

--- a/libs/xSdk.Data.Vault/src/Data/JwtAuth.cs
+++ b/libs/xSdk.Data.Vault/src/Data/JwtAuth.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public sealed class JwtAuth

--- a/libs/xSdk.Data.Vault/src/Data/LdapAuth.cs
+++ b/libs/xSdk.Data.Vault/src/Data/LdapAuth.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public sealed class LdapAuth

--- a/libs/xSdk.Data.Vault/src/Data/OidcAuth.cs
+++ b/libs/xSdk.Data.Vault/src/Data/OidcAuth.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.Vault/src/Data/ReadOnlyVaultRepository.cs
+++ b/libs/xSdk.Data.Vault/src/Data/ReadOnlyVaultRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using NLog;
 using VaultSharp;

--- a/libs/xSdk.Data.Vault/src/Data/TokenAuth.cs
+++ b/libs/xSdk.Data.Vault/src/Data/TokenAuth.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public sealed class TokenAuth

--- a/libs/xSdk.Data.Vault/src/Data/UsernamePasswordAuth.cs
+++ b/libs/xSdk.Data.Vault/src/Data/UsernamePasswordAuth.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public sealed class UsernamePasswordAuth

--- a/libs/xSdk.Data.Vault/src/Data/VaultAuthenticationMethod.cs
+++ b/libs/xSdk.Data.Vault/src/Data/VaultAuthenticationMethod.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public enum VaultAuthenticationMethod

--- a/libs/xSdk.Data.Vault/src/Data/VaultConnectionBuilder.cs
+++ b/libs/xSdk.Data.Vault/src/Data/VaultConnectionBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 internal sealed class VaultConnectionBuilder : ConnectionBuilder

--- a/libs/xSdk.Data.Vault/src/Data/VaultDatabase.cs
+++ b/libs/xSdk.Data.Vault/src/Data/VaultDatabase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using VaultSharp;
 using VaultSharp.V1.AuthMethods;
 using VaultSharp.V1.AuthMethods.AppRole;

--- a/libs/xSdk.Data.Vault/src/Data/VaultDatabaseSetup.cs
+++ b/libs/xSdk.Data.Vault/src/Data/VaultDatabaseSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.Vault/src/Data/VaultRepository.cs
+++ b/libs/xSdk.Data.Vault/src/Data/VaultRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using NLog;
 using VaultSharp;
 using xSdk.Extensions.Variable;

--- a/libs/xSdk.Data.Vault/src/Data/VaultSetup.cs
+++ b/libs/xSdk.Data.Vault/src/Data/VaultSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json.Serialization;
 using xSdk.Extensions.Variable;
 using xSdk.Extensions.Variable.Attributes;

--- a/libs/xSdk.Data.Vault/src/HostBuilderExtensions.cs
+++ b/libs/xSdk.Data.Vault/src/HostBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using xSdk.Data;
 using xSdk.Hosting;

--- a/libs/xSdk.Data.Vault/tests/Globals.cs
+++ b/libs/xSdk.Data.Vault/tests/Globals.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 internal static class Globals

--- a/libs/xSdk.Data.Vault/tests/InsertDataTests.cs
+++ b/libs/xSdk.Data.Vault/tests/InsertDataTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data.Vault/tests/Mocks/DatabaseFixture.cs
+++ b/libs/xSdk.Data.Vault/tests/Mocks/DatabaseFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Images;

--- a/libs/xSdk.Data.Vault/tests/Mocks/TestEntity.cs
+++ b/libs/xSdk.Data.Vault/tests/Mocks/TestEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal class TestEntity : IEntity

--- a/libs/xSdk.Data.Vault/tests/Mocks/TestEntityExtensions.cs
+++ b/libs/xSdk.Data.Vault/tests/Mocks/TestEntityExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 internal static class TestEntityExtensions

--- a/libs/xSdk.Data.Vault/tests/Mocks/TestEntityFakes.cs
+++ b/libs/xSdk.Data.Vault/tests/Mocks/TestEntityFakes.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Bogus;
 
 namespace xSdk.Data.Mocks;

--- a/libs/xSdk.Data/src/Data/ConnectionBuilder.cs
+++ b/libs/xSdk.Data/src/Data/ConnectionBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data/src/Data/Converters/Json/ClaimsConverter.cs
+++ b/libs/xSdk.Data/src/Data/Converters/Json/ClaimsConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/libs/xSdk.Data/src/Data/Converters/Json/ObjectConverter.cs
+++ b/libs/xSdk.Data/src/Data/Converters/Json/ObjectConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/libs/xSdk.Data/src/Data/Converters/Mapper/ClaimListConverter.cs
+++ b/libs/xSdk.Data/src/Data/Converters/Mapper/ClaimListConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Claims;
 using xSdk.Security.Claims;
 

--- a/libs/xSdk.Data/src/Data/Converters/Mapper/JsonElementConverter.cs
+++ b/libs/xSdk.Data/src/Data/Converters/Mapper/JsonElementConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using xSdk.Shared;
 

--- a/libs/xSdk.Data/src/Data/Converters/Mapper/SemVerConverter.cs
+++ b/libs/xSdk.Data/src/Data/Converters/Mapper/SemVerConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using NLog;
 
 namespace xSdk.Data.Converters.Mapper;

--- a/libs/xSdk.Data/src/Data/Converters/Yaml/SemVerVersionConverter.cs
+++ b/libs/xSdk.Data/src/Data/Converters/Yaml/SemVerVersionConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.Utilities;

--- a/libs/xSdk.Data/src/Data/DataExtensions.cs
+++ b/libs/xSdk.Data/src/Data/DataExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using Mapster;
 using MapsterMapper;

--- a/libs/xSdk.Data/src/Data/Database.cs
+++ b/libs/xSdk.Data/src/Data/Database.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Concurrent;
 using NLog;
 using xSdk.Shared;

--- a/libs/xSdk.Data/src/Data/DatabaseSetup.cs
+++ b/libs/xSdk.Data/src/Data/DatabaseSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 using xSdk.Extensions.Variable;

--- a/libs/xSdk.Data/src/Data/DatabaseSetupExtensions.cs
+++ b/libs/xSdk.Data/src/Data/DatabaseSetupExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data/src/Data/DatalayerBuilder.cs
+++ b/libs/xSdk.Data/src/Data/DatalayerBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 

--- a/libs/xSdk.Data/src/Data/DatalayerFactory.cs
+++ b/libs/xSdk.Data/src/Data/DatalayerFactory.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data/src/Data/EntityMappingProfile.cs
+++ b/libs/xSdk.Data/src/Data/EntityMappingProfile.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 internal class EntityMappingProfile<TEntity> : MappingProfile

--- a/libs/xSdk.Data/src/Data/FakeGenerator.cs
+++ b/libs/xSdk.Data/src/Data/FakeGenerator.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Bogus;
 using xSdk.Shared;
 

--- a/libs/xSdk.Data/src/Data/FakeRepository.cs
+++ b/libs/xSdk.Data/src/Data/FakeRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.ObjectModel;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data/src/Data/Fakes.cs
+++ b/libs/xSdk.Data/src/Data/Fakes.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Bogus;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data/src/Data/InternalDatabaseSetup.cs
+++ b/libs/xSdk.Data/src/Data/InternalDatabaseSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 internal class InternalDatabaseSetup : DatabaseSetup

--- a/libs/xSdk.Data/src/Data/MappingFactory.cs
+++ b/libs/xSdk.Data/src/Data/MappingFactory.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Mapster;
 using MapsterMapper;
 using NLog;

--- a/libs/xSdk.Data/src/Data/MappingProfile.cs
+++ b/libs/xSdk.Data/src/Data/MappingProfile.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Mapster;
 using NLog;
 

--- a/libs/xSdk.Data/src/Data/ModelMappingProfile.cs
+++ b/libs/xSdk.Data/src/Data/ModelMappingProfile.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Mapster;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data/src/Data/Repository.cs
+++ b/libs/xSdk.Data/src/Data/Repository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations.Schema;
 using xSdk.Extensions.Variable;
 using xSdk.Hosting;

--- a/libs/xSdk.Data/src/Data/ServiceCollectionExtensions.cs
+++ b/libs/xSdk.Data/src/Data/ServiceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data/src/Hosting/DatabaseHostFixture.cs
+++ b/libs/xSdk.Data/src/Hosting/DatabaseHostFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Hosting;

--- a/libs/xSdk.Data/tests/Converters/Json/ClaimsConverterTests.cs
+++ b/libs/xSdk.Data/tests/Converters/Json/ClaimsConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Claims;
 using System.Text.Json;
 using xSdk.Data.Converters.Json;

--- a/libs/xSdk.Data/tests/Converters/Json/ObjectConverterTests.cs
+++ b/libs/xSdk.Data/tests/Converters/Json/ObjectConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using xSdk.Data.Converters.Json;
 

--- a/libs/xSdk.Data/tests/Converters/Mapper/ClaimListConverterTests.cs
+++ b/libs/xSdk.Data/tests/Converters/Mapper/ClaimListConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Claims;
 using xSdk.Security.Claims;
 

--- a/libs/xSdk.Data/tests/Converters/Mapper/JsonElementConverterTests.cs
+++ b/libs/xSdk.Data/tests/Converters/Mapper/JsonElementConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 
 namespace xSdk.Data.Converters.Mapper;

--- a/libs/xSdk.Data/tests/Converters/Mapper/SemVerConverterTests.cs
+++ b/libs/xSdk.Data/tests/Converters/Mapper/SemVerConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Converters.Mapper;
 
 public class SemVerConverterTests

--- a/libs/xSdk.Data/tests/Converters/Yaml/SemVerVersionConverterTests.cs
+++ b/libs/xSdk.Data/tests/Converters/Yaml/SemVerVersionConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Converters.Yaml;
 
 namespace xSdk.Data.Tests.Converters.Yaml;

--- a/libs/xSdk.Data/tests/DataExtensionsTests.cs
+++ b/libs/xSdk.Data/tests/DataExtensionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using MapsterMapper;
 using xSdk.Data.Mocks;
 

--- a/libs/xSdk.Data/tests/DatabaseSetupTests.cs
+++ b/libs/xSdk.Data/tests/DatabaseSetupTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations;
 
 namespace xSdk.Data.Tests;

--- a/libs/xSdk.Data/tests/EntityTests.cs
+++ b/libs/xSdk.Data/tests/EntityTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data/tests/FakeRepositoryTests.cs
+++ b/libs/xSdk.Data/tests/FakeRepositoryTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data/tests/FakerTests.cs
+++ b/libs/xSdk.Data/tests/FakerTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data/tests/GuidPKTests.cs
+++ b/libs/xSdk.Data/tests/GuidPKTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public class GuidPKTests

--- a/libs/xSdk.Data/tests/GuidStringPKTests.cs
+++ b/libs/xSdk.Data/tests/GuidStringPKTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public class GuidStringPKTests

--- a/libs/xSdk.Data/tests/KeyValuePKTests.cs
+++ b/libs/xSdk.Data/tests/KeyValuePKTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public class KeyValuePKTests

--- a/libs/xSdk.Data/tests/MappingTests.cs
+++ b/libs/xSdk.Data/tests/MappingTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Data/tests/Mocks/TestEntity.cs
+++ b/libs/xSdk.Data/tests/Mocks/TestEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations;
 
 namespace xSdk.Data.Mocks;

--- a/libs/xSdk.Data/tests/Mocks/TestEntityFakes.cs
+++ b/libs/xSdk.Data/tests/Mocks/TestEntityFakes.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Bogus;
 
 namespace xSdk.Data.Mocks;

--- a/libs/xSdk.Data/tests/Mocks/TestMappingProfile.cs
+++ b/libs/xSdk.Data/tests/Mocks/TestMappingProfile.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Mapster;
 using xSdk.Data.Converters.Mapper;
 

--- a/libs/xSdk.Data/tests/Mocks/TestModel.cs
+++ b/libs/xSdk.Data/tests/Mocks/TestModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations;
 
 namespace xSdk.Data.Mocks;

--- a/libs/xSdk.Data/tests/ModelTests.cs
+++ b/libs/xSdk.Data/tests/ModelTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Mocks;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/HateoasItem.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/HateoasItem.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json.Serialization;
 
 namespace xSdk.Extensions.Links;

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/IHateoasItem.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/IHateoasItem.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Links;
 
 public interface IHateoasItem

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/ILinksPluginBuilder.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/ILinksPluginBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Plugin;
 
 namespace xSdk.Extensions.Links;

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/ILinksService.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/ILinksService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Extensions.Links;

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/IPolicy.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/IPolicy.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Links;
 
 public interface IPolicy

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/LinksAttribute.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/LinksAttribute.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Links;
 
 [AttributeUsage(AttributeTargets.Method)]

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/LinksOptions.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/LinksOptions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Links;
 
 public class LinksOptions

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/LinksOptionsExtensions.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/LinksOptionsExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Extensions.Links;

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/LinksService.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/LinksService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/MethodAnalyzer.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/MethodAnalyzer.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/MethodDescription.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/MethodDescription.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 
 namespace xSdk.Extensions.Links;

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/Policy.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/Policy.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Extensions.Links;

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/PolicyExtensions.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/PolicyExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Extensions.Links;

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/RoutedLink.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/RoutedLink.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Http;
 using xSdk.Data;
 

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/RoutedLinkBuilder.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/RoutedLinkBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using HandlebarsDotNet;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/ServiceCollectionExtensions.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Extensions/Links/ServiceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using xSdk.Extensions.Plugin;

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Plugins/Links/HostBuilderExtensions.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Plugins/Links/HostBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using xSdk.Extensions.Links;
 using xSdk.Hosting;

--- a/libs/xSdk.Extensions.AspNetCore.Links/src/Plugins/Links/LinksPlugin.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/src/Plugins/Links/LinksPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.Links;
 using xSdk.Hosting;

--- a/libs/xSdk.Extensions.AspNetCore.Links/tests/HateoasItemTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/tests/HateoasItemTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Links;
 
 namespace xSdk.Extensions.AspNetCore.Links.Tests;

--- a/libs/xSdk.Extensions.AspNetCore.Links/tests/LinksAttributeTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/tests/LinksAttributeTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Links;
 
 namespace xSdk.Extensions.AspNetCore.Links.Tests;

--- a/libs/xSdk.Extensions.AspNetCore.Links/tests/LinksOptionsExtensionsTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/tests/LinksOptionsExtensionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 using xSdk.Extensions.Links;
 

--- a/libs/xSdk.Extensions.AspNetCore.Links/tests/LinksOptionsTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/tests/LinksOptionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Links;
 
 namespace xSdk.Extensions.AspNetCore.Links.Tests;

--- a/libs/xSdk.Extensions.AspNetCore.Links/tests/MethodDescriptionTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/tests/MethodDescriptionTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 using xSdk.Extensions.Links;
 

--- a/libs/xSdk.Extensions.AspNetCore.Links/tests/PolicyExtensionsTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/tests/PolicyExtensionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 using xSdk.Extensions.Links;
 

--- a/libs/xSdk.Extensions.AspNetCore.Links/tests/PolicyTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/tests/PolicyTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 using xSdk.Extensions.Links;
 

--- a/libs/xSdk.Extensions.AspNetCore.Links/tests/RoutedLinkTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore.Links/tests/RoutedLinkTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 using xSdk.Extensions.Links;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Controllers/HealthController.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Controllers/HealthController.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;

--- a/libs/xSdk.Extensions.AspNetCore/src/Controllers/VariableController.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Controllers/VariableController.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;

--- a/libs/xSdk.Extensions.AspNetCore/src/Data/Models/VariableModel.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Data/Models/VariableModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel;
 using xSdk.Extensions.Variable;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Data/Models/VariableModelExamples.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Data/Models/VariableModelExamples.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Bogus;
 
 namespace xSdk.Data.Models;

--- a/libs/xSdk.Extensions.AspNetCore/src/Extensions/Web/ProblemDetailsExamples.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Extensions/Web/ProblemDetailsExamples.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Bogus;
 using Microsoft.AspNetCore.Mvc;
 using xSdk.Data;

--- a/libs/xSdk.Extensions.AspNetCore/src/Hosting/WebHost.Application.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Hosting/WebHost.Application.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Hosting/WebHost.Kestrel.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Hosting/WebHost.Kestrel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;

--- a/libs/xSdk.Extensions.AspNetCore/src/Hosting/WebHost.Services.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Hosting/WebHost.Services.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.Plugin;

--- a/libs/xSdk.Extensions.AspNetCore/src/Hosting/WebHost.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Hosting/WebHost.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using NLog;

--- a/libs/xSdk.Extensions.AspNetCore/src/Hosting/WebHostSetup.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Hosting/WebHostSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 using xSdk.Extensions.Variable.Attributes;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Hosting/WebSetupExtensions.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Hosting/WebSetupExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //using NLog;
 
 //namespace xSdk.Hosting

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/Authentication/ApiKeySetup.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/Authentication/ApiKeySetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 using xSdk.Extensions.Variable.Attributes;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/Authentication/AuthenticationBuilderExtensions.ApiKey.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/Authentication/AuthenticationBuilderExtensions.ApiKey.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using AspNetCore.Authentication.ApiKey;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/Authentication/AuthenticationBuilderExtensions.ApiKeyRepository.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/Authentication/AuthenticationBuilderExtensions.ApiKeyRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/Authentication/AuthenticationBuilderExtensions.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/Authentication/AuthenticationBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using NLog;
 
 namespace xSdk.Plugins.Authentication;

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/Authentication/AuthenticationPlugin.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/Authentication/AuthenticationPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/Authentication/HostBuilderExtensions.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/Authentication/HostBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using xSdk.Hosting;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/Compression/CompressionPlugin.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/Compression/CompressionPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.DependencyInjection;

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/Compression/HostBuilderExtensions.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/Compression/HostBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using xSdk.Hosting;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/DataProtection/DataProtectionPlugin.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/DataProtection/DataProtectionPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.DependencyInjection;

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/DataProtection/DataProtectionSetup.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/DataProtection/DataProtectionSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 using xSdk.Extensions.Variable.Attributes;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/DataProtection/HostBuilderExtensions.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/DataProtection/HostBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using xSdk.Hosting;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/Documentation/DocumentationPlugin.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/Documentation/DocumentationPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Asp.Versioning.ApiExplorer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/Documentation/DocumentationSetup.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/Documentation/DocumentationSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 using xSdk.Extensions.Variable.Attributes;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/Documentation/HostBuilderExtensions.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/Documentation/HostBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using xSdk.Hosting;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/WebApi/HostBuilderExtensions.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/WebApi/HostBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using xSdk.Hosting;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/WebApi/PlainTextFormatter.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/WebApi/PlainTextFormatter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text;
 using Microsoft.AspNetCore.Mvc.Formatters;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/WebApi/WebApiPlugin.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/WebApi/WebApiPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics;
 using Asp.Versioning;
 using FluentValidation;

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/WebSecurity/HostBuilderExtensions.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/WebSecurity/HostBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using xSdk.Hosting;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/WebSecurity/WebSecurityPlugin.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/WebSecurity/WebSecurityPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;

--- a/libs/xSdk.Extensions.AspNetCore/src/Plugins/WebSecurity/WebSecuritySetup.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Plugins/WebSecurity/WebSecuritySetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 using xSdk.Extensions.Variable.Attributes;
 

--- a/libs/xSdk.Extensions.AspNetCore/src/Shared/AssemblyCollector.cs
+++ b/libs/xSdk.Extensions.AspNetCore/src/Shared/AssemblyCollector.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 using NLog;
 using xSdk.Extensions.IO;

--- a/libs/xSdk.Extensions.AspNetCore/tests/Plugins/Compression/CompressionPluginTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore/tests/Plugins/Compression/CompressionPluginTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.Plugin;
 using xSdk.Hosting;

--- a/libs/xSdk.Extensions.AspNetCore/tests/Plugins/DataProtection/DataProtectionSetupTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore/tests/Plugins/DataProtection/DataProtectionSetupTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Hosting;
 
 namespace xSdk.Plugins.DataProtection;

--- a/libs/xSdk.Extensions.AspNetCore/tests/Plugins/Documentation/DocumentationPluginTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore/tests/Plugins/Documentation/DocumentationPluginTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Plugin;
 using xSdk.Hosting;
 using xSdk.Plugins.Documentation.Mocks;

--- a/libs/xSdk.Extensions.AspNetCore/tests/Plugins/Documentation/DocumentationSetupTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore/tests/Plugins/Documentation/DocumentationSetupTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 using xSdk.Hosting;
 using xSdk.Plugins.Documentation.Mocks;

--- a/libs/xSdk.Extensions.AspNetCore/tests/Plugins/Documentation/Mocks/DocumentationPluginBuilderMock.cs
+++ b/libs/xSdk.Extensions.AspNetCore/tests/Plugins/Documentation/Mocks/DocumentationPluginBuilderMock.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Asp.Versioning.ApiExplorer;
 using Microsoft.OpenApi;
 using xSdk.Extensions.Plugin;

--- a/libs/xSdk.Extensions.AspNetCore/tests/Plugins/WebApi/WebApiPluginTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore/tests/Plugins/WebApi/WebApiPluginTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.Plugin;
 using xSdk.Hosting;

--- a/libs/xSdk.Extensions.AspNetCore/tests/Plugins/WebSecurity/WebSecuritySetupTests.cs
+++ b/libs/xSdk.Extensions.AspNetCore/tests/Plugins/WebSecurity/WebSecuritySetupTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.Plugin;
 using xSdk.Hosting;

--- a/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/CloudEventExtensions.cs
+++ b/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/CloudEventExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using CloudNative.CloudEvents;
 using xSdk.Data;

--- a/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/CloudEventFactory.cs
+++ b/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/CloudEventFactory.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using CloudNative.CloudEvents;
 using CloudNative.CloudEvents.SystemTextJson;

--- a/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/CloudEventJsonInputFormatter.cs
+++ b/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/CloudEventJsonInputFormatter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text;
 using CloudNative.CloudEvents;
 using CloudNative.CloudEvents.AspNetCore;

--- a/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/CloudEventStringConverter.cs
+++ b/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/CloudEventStringConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text;
 using CloudNative.CloudEvents;
 using xSdk.Data;

--- a/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/CloudEventWebExtensions.cs
+++ b/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/CloudEventWebExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Net.Http.Headers;
 using System.Net.Mime;
 using System.Text;

--- a/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/ExceptionExtensions.cs
+++ b/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/ExceptionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using CloudNative.CloudEvents;
 
 namespace xSdk.Extensions.CloudEvents;

--- a/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/ModelExtensions.cs
+++ b/libs/xSdk.Extensions.CloudEvents/src/Extensions/CloudEvents/ModelExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using CloudNative.CloudEvents;
 using xSdk.Data;
 

--- a/libs/xSdk.Extensions.CloudEvents/src/Plugins/CloudEvents/CloudEventPlugin.cs
+++ b/libs/xSdk.Extensions.CloudEvents/src/Plugins/CloudEvents/CloudEventPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Mvc;
 using xSdk.Extensions.CloudEvents;
 using xSdk.Hosting;

--- a/libs/xSdk.Extensions.CloudEvents/src/Plugins/CloudEvents/HostBuilderExtensions.cs
+++ b/libs/xSdk.Extensions.CloudEvents/src/Plugins/CloudEvents/HostBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using xSdk.Hosting;
 

--- a/libs/xSdk.Extensions.CloudEvents/tests/Extensions/CloudEvents/CloudEventExtensionsTests.cs
+++ b/libs/xSdk.Extensions.CloudEvents/tests/Extensions/CloudEvents/CloudEventExtensionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using CloudNative.CloudEvents;
 using xSdk.Extensions.CloudEvents;
 using xSdk.Hosting;

--- a/libs/xSdk.Extensions.CloudEvents/tests/Extensions/CloudEvents/CloudEventFactoryTests.cs
+++ b/libs/xSdk.Extensions.CloudEvents/tests/Extensions/CloudEvents/CloudEventFactoryTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using CloudNative.CloudEvents;
 using xSdk.Extensions.CloudEvents;
 using xSdk.Hosting;

--- a/libs/xSdk.Extensions.CloudEvents/tests/Extensions/CloudEvents/CloudEventStringConverterTests.cs
+++ b/libs/xSdk.Extensions.CloudEvents/tests/Extensions/CloudEvents/CloudEventStringConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using CloudNative.CloudEvents;
 using xSdk.Extensions.CloudEvents;
 using xSdk.Hosting;

--- a/libs/xSdk.Extensions.CloudEvents/tests/Extensions/CloudEvents/ExceptionExtensionsTests.cs
+++ b/libs/xSdk.Extensions.CloudEvents/tests/Extensions/CloudEvents/ExceptionExtensionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using CloudNative.CloudEvents;
 using xSdk.Extensions.CloudEvents;

--- a/libs/xSdk.Extensions.CloudEvents/tests/Extensions/CloudEvents/ModelExtensionsTests.cs
+++ b/libs/xSdk.Extensions.CloudEvents/tests/Extensions/CloudEvents/ModelExtensionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using CloudNative.CloudEvents;
 using xSdk.Data;
 using xSdk.Extensions.CloudEvents;

--- a/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ClearCommand.cs
+++ b/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ClearCommand.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel;
 using Spectre.Console.Cli;
 

--- a/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ConsoleCommand.cs
+++ b/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ConsoleCommand.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel;
 using Spectre.Console.Cli;
 

--- a/libs/xSdk.Extensions.Commands/src/Extensions/Commands/DefaultCommand.cs
+++ b/libs/xSdk.Extensions.Commands/src/Extensions/Commands/DefaultCommand.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Spectre.Console.Cli;
 
 namespace xSdk.Extensions.Commands;

--- a/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ExitCommand.cs
+++ b/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ExitCommand.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel;
 using Spectre.Console.Cli;
 

--- a/libs/xSdk.Extensions.Commands/src/Extensions/Commands/HostExtensions.cs
+++ b/libs/xSdk.Extensions.Commands/src/Extensions/Commands/HostExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NLog;

--- a/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ICommandLinePluginBuilder.cs
+++ b/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ICommandLinePluginBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Spectre.Console.Cli;
 using xSdk.Extensions.Plugin;
 

--- a/libs/xSdk.Extensions.Commands/src/Extensions/Commands/IReplBuilder.cs
+++ b/libs/xSdk.Extensions.Commands/src/Extensions/Commands/IReplBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Commands;
 
 public interface IReplBuilder

--- a/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ReplBuilder.cs
+++ b/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ReplBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 using xSdk.Hosting;
 

--- a/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ServiceCollectionExtensions.cs
+++ b/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ServiceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Spectre.Console.Cli;

--- a/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ServiceRegistrar.cs
+++ b/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ServiceRegistrar.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console.Cli;
 

--- a/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ServiceResolver.cs
+++ b/libs/xSdk.Extensions.Commands/src/Extensions/Commands/ServiceResolver.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Spectre.Console.Cli;
 
 namespace xSdk.Extensions.Commands;

--- a/libs/xSdk.Extensions.Commands/src/Plugins/Commands/CommandPlugin.cs
+++ b/libs/xSdk.Extensions.Commands/src/Plugins/Commands/CommandPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Hosting;
 
 namespace xSdk.Plugins.Commands;

--- a/libs/xSdk.Extensions.Commands/src/Plugins/Commands/HostBuilderExtensions.cs
+++ b/libs/xSdk.Extensions.Commands/src/Plugins/Commands/HostBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using xSdk.Extensions.Commands;
 using xSdk.Hosting;

--- a/libs/xSdk.Extensions.Commands/tests/Extensions/Commands/CommandDefinitionsTests.cs
+++ b/libs/xSdk.Extensions.Commands/tests/Extensions/Commands/CommandDefinitionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Commands.Tests.Extensions.Commands;
 
 public class CommandDefinitionsTests

--- a/libs/xSdk.Extensions.Commands/tests/Extensions/Commands/ServiceRegistrarTests.cs
+++ b/libs/xSdk.Extensions.Commands/tests/Extensions/Commands/ServiceRegistrarTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.Commands;
 

--- a/libs/xSdk.Extensions.Commands/tests/Extensions/Commands/ServiceResolverTests.cs
+++ b/libs/xSdk.Extensions.Commands/tests/Extensions/Commands/ServiceResolverTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.Commands;
 

--- a/libs/xSdk.Extensions.Commands/tests/Plugins/Commands/CommandPluginTests.cs
+++ b/libs/xSdk.Extensions.Commands/tests/Plugins/Commands/CommandPluginTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.Plugin;
 using xSdk.Hosting;

--- a/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/ITelemetryPluginBuilder.cs
+++ b/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/ITelemetryPluginBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using OpenTelemetry.Instrumentation.EntityFrameworkCore;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;

--- a/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/ITelemetryService.cs
+++ b/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/ITelemetryService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;

--- a/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/ServiceCollectionExtensions.cs
+++ b/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/ServiceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 

--- a/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/TelemetryConfigurator.cs
+++ b/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/TelemetryConfigurator.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Instrumentation.EntityFrameworkCore;

--- a/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/TelemetryService.cs
+++ b/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/TelemetryService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;

--- a/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/TelemetrySetup.cs
+++ b/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/TelemetrySetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 using xSdk.Extensions.Variable.Attributes;
 

--- a/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/VariableResourceDetector.cs
+++ b/libs/xSdk.Extensions.Telemetry/src/Extensions/Telemetry/VariableResourceDetector.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using OpenTelemetry.Resources;
 
 namespace xSdk.Extensions.Telemetry;

--- a/libs/xSdk.Extensions.Telemetry/src/Plugins/Telemetry/HostBuilderExtensions.cs
+++ b/libs/xSdk.Extensions.Telemetry/src/Plugins/Telemetry/HostBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using xSdk.Extensions.Telemetry;
 using xSdk.Hosting;

--- a/libs/xSdk.Extensions.Telemetry/src/Plugins/Telemetry/TelemetryPlugin.cs
+++ b/libs/xSdk.Extensions.Telemetry/src/Plugins/Telemetry/TelemetryPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.Plugin;
 using xSdk.Extensions.Telemetry;

--- a/libs/xSdk.Plugin/src/Data/Annotations/DataAnnotationAttribute.cs
+++ b/libs/xSdk.Plugin/src/Data/Annotations/DataAnnotationAttribute.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations;
 using xSdk.Shared;
 

--- a/libs/xSdk.Plugin/src/Data/Annotations/MaxAttribute.cs
+++ b/libs/xSdk.Plugin/src/Data/Annotations/MaxAttribute.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Annotations;
 
 /// <summary>

--- a/libs/xSdk.Plugin/src/Data/Annotations/MinAttribute.cs
+++ b/libs/xSdk.Plugin/src/Data/Annotations/MinAttribute.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Annotations;
 
 /// <summary>

--- a/libs/xSdk.Plugin/src/Data/Converters/Json/DateTimeConverter.cs
+++ b/libs/xSdk.Plugin/src/Data/Converters/Json/DateTimeConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/libs/xSdk.Plugin/src/Data/Converters/Json/SemVerConverter.cs
+++ b/libs/xSdk.Plugin/src/Data/Converters/Json/SemVerConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/libs/xSdk.Plugin/src/Data/Converters/Json/StageConverter.cs
+++ b/libs/xSdk.Plugin/src/Data/Converters/Json/StageConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/libs/xSdk.Plugin/src/Data/Converters/Json/VersionConverter.cs
+++ b/libs/xSdk.Plugin/src/Data/Converters/Json/VersionConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/libs/xSdk.Plugin/src/Data/Converters/Mapper/GuidConverter.cs
+++ b/libs/xSdk.Plugin/src/Data/Converters/Mapper/GuidConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel;
 
 namespace xSdk.Data.Converters.Mapper;

--- a/libs/xSdk.Plugin/src/Data/Entity.cs
+++ b/libs/xSdk.Plugin/src/Data/Entity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;

--- a/libs/xSdk.Plugin/src/Data/GuidPK.cs
+++ b/libs/xSdk.Plugin/src/Data/GuidPK.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Converters.Mapper;
 using xSdk.Shared;
 

--- a/libs/xSdk.Plugin/src/Data/GuidStringPK.cs
+++ b/libs/xSdk.Plugin/src/Data/GuidStringPK.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Converters.Mapper;
 using xSdk.Shared;
 

--- a/libs/xSdk.Plugin/src/Data/IConnectionBuilder.cs
+++ b/libs/xSdk.Plugin/src/Data/IConnectionBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public interface IConnectionBuilder

--- a/libs/xSdk.Plugin/src/Data/IDataMigrationPlugin.cs
+++ b/libs/xSdk.Plugin/src/Data/IDataMigrationPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Plugin;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Plugin/src/Data/IDatabase.cs
+++ b/libs/xSdk.Plugin/src/Data/IDatabase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public interface IDatabase : IDisposable

--- a/libs/xSdk.Plugin/src/Data/IDatabaseSetup.cs
+++ b/libs/xSdk.Plugin/src/Data/IDatabaseSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Plugin/src/Data/IDatalayerBuilder.cs
+++ b/libs/xSdk.Plugin/src/Data/IDatalayerBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public interface IDatalayerBuilder

--- a/libs/xSdk.Plugin/src/Data/IDatalayerFactory.cs
+++ b/libs/xSdk.Plugin/src/Data/IDatalayerFactory.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Plugin/src/Data/IDatalayerPlugin.cs
+++ b/libs/xSdk.Plugin/src/Data/IDatalayerPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.Plugin;
 

--- a/libs/xSdk.Plugin/src/Data/IEntity.cs
+++ b/libs/xSdk.Plugin/src/Data/IEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public interface IEntity

--- a/libs/xSdk.Plugin/src/Data/IModel.cs
+++ b/libs/xSdk.Plugin/src/Data/IModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public interface IModel

--- a/libs/xSdk.Plugin/src/Data/IPrimaryKey.cs
+++ b/libs/xSdk.Plugin/src/Data/IPrimaryKey.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public interface IPrimaryKey

--- a/libs/xSdk.Plugin/src/Data/IRepository.cs
+++ b/libs/xSdk.Plugin/src/Data/IRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public interface IRepository : IDisposable { }

--- a/libs/xSdk.Plugin/src/Data/JsonHelper.cs
+++ b/libs/xSdk.Plugin/src/Data/JsonHelper.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 using NLog;

--- a/libs/xSdk.Plugin/src/Data/KeyValuePK.cs
+++ b/libs/xSdk.Plugin/src/Data/KeyValuePK.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public sealed class KeyValuePK : PrimaryKey<string>

--- a/libs/xSdk.Plugin/src/Data/Model.cs
+++ b/libs/xSdk.Plugin/src/Data/Model.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;

--- a/libs/xSdk.Plugin/src/Data/PrimaryKey.cs
+++ b/libs/xSdk.Plugin/src/Data/PrimaryKey.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Data;

--- a/libs/xSdk.Plugin/src/Extensions/Authentication/ApiKeyModelExtensions.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Authentication/ApiKeyModelExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.ObjectModel;
 using System.Security.Claims;
 using AspNetCore.Authentication.ApiKey;

--- a/libs/xSdk.Plugin/src/Extensions/Authentication/ApiKeySignature.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Authentication/ApiKeySignature.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Authentication;
 
 public static class ApiKeySignature

--- a/libs/xSdk.Plugin/src/Extensions/Authentication/ClaimsPrincipalExtensions.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Authentication/ClaimsPrincipalExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Claims;
 using CommunityToolkit.Diagnostics;
 using xSdk.Security.Claims;

--- a/libs/xSdk.Plugin/src/Extensions/Authentication/ConcreteApiKey.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Authentication/ConcreteApiKey.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Claims;
 using AspNetCore.Authentication.ApiKey;
 using xSdk.Data;

--- a/libs/xSdk.Plugin/src/Extensions/Authentication/DefaultApiKeyHandler.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Authentication/DefaultApiKeyHandler.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //using AspNetCore.Authentication.ApiKeyName;
 
 //namespace xSdk.Extensions.Authentication

--- a/libs/xSdk.Plugin/src/Extensions/Authentication/IApiKeyHandler.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Authentication/IApiKeyHandler.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using AspNetCore.Authentication.ApiKey;
 
 namespace xSdk.Extensions.Authentication;

--- a/libs/xSdk.Plugin/src/Extensions/Authentication/IApiKeyModel.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Authentication/IApiKeyModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using AspNetCore.Authentication.ApiKey;
 using xSdk.Data;
 using xSdk.Security.Claims;

--- a/libs/xSdk.Plugin/src/Extensions/Commands/CommandlineParser.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Commands/CommandlineParser.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 

--- a/libs/xSdk.Plugin/src/Extensions/Commands/DefaultCommandSettings.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Commands/DefaultCommandSettings.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel;
 using Spectre.Console.Cli;
 

--- a/libs/xSdk.Plugin/src/Extensions/IO/FileSystemContext.cs
+++ b/libs/xSdk.Plugin/src/Extensions/IO/FileSystemContext.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.IO;
 
 public enum FileSystemContext

--- a/libs/xSdk.Plugin/src/Extensions/IO/FileSystemExtensions.cs
+++ b/libs/xSdk.Plugin/src/Extensions/IO/FileSystemExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Zio;
 
 namespace xSdk.Extensions.IO;

--- a/libs/xSdk.Plugin/src/Extensions/IO/FileSystemHelper.cs
+++ b/libs/xSdk.Plugin/src/Extensions/IO/FileSystemHelper.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 using xSdk.Hosting;
 using Zio;

--- a/libs/xSdk.Plugin/src/Extensions/IO/IFileSystemResult.cs
+++ b/libs/xSdk.Plugin/src/Extensions/IO/IFileSystemResult.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Zio;
 
 namespace xSdk.Extensions.IO;

--- a/libs/xSdk.Plugin/src/Extensions/IO/IFileSystemService.cs
+++ b/libs/xSdk.Plugin/src/Extensions/IO/IFileSystemService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.IO;
 
 public interface IFileSystemService

--- a/libs/xSdk.Plugin/src/Extensions/Plugin/IPlugin.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Plugin/IPlugin.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Plugin;
 
 public interface IPlugin : IPluginDescription { }

--- a/libs/xSdk.Plugin/src/Extensions/Plugin/IPluginBuilder.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Plugin/IPluginBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Plugin;
 
 public interface IPluginBuilder : IPluginDescription { }

--- a/libs/xSdk.Plugin/src/Extensions/Plugin/IPluginDescription.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Plugin/IPluginDescription.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Plugin;
 
 public interface IPluginDescription

--- a/libs/xSdk.Plugin/src/Extensions/Plugin/IPluginService.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Plugin/IPluginService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 
 namespace xSdk.Extensions.Plugin;

--- a/libs/xSdk.Plugin/src/Extensions/Plugin/IPluginServiceExtensions.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Plugin/IPluginServiceExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Plugin;
 
 public static class IPluginServiceExtensions

--- a/libs/xSdk.Plugin/src/Extensions/Plugin/PluginBuilderBase.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Plugin/PluginBuilderBase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Plugin;
 
 public abstract class PluginBuilderBase : PluginDescription, IPluginBuilder { }

--- a/libs/xSdk.Plugin/src/Extensions/Plugin/PluginDescription.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Plugin/PluginDescription.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using NLog;
 
 namespace xSdk.Extensions.Plugin;

--- a/libs/xSdk.Plugin/src/Extensions/Variable/Attributes/VariableAttribute.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Variable/Attributes/VariableAttribute.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Annotations;
 
 namespace xSdk.Extensions.Variable.Attributes;

--- a/libs/xSdk.Plugin/src/Extensions/Variable/Attributes/VariableNoPrefixAttribute.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Variable/Attributes/VariableNoPrefixAttribute.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Variable.Attributes;
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]

--- a/libs/xSdk.Plugin/src/Extensions/Variable/Attributes/VariablePrefixAttribute.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Variable/Attributes/VariablePrefixAttribute.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Variable.Attributes;
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]

--- a/libs/xSdk.Plugin/src/Extensions/Variable/IEnvironmentSetup.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Variable/IEnvironmentSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Variable;
 
 public interface IEnvironmentSetup : ISetup

--- a/libs/xSdk.Plugin/src/Extensions/Variable/ISetup.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Variable/ISetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations;
 
 namespace xSdk.Extensions.Variable;

--- a/libs/xSdk.Plugin/src/Extensions/Variable/IVariable.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Variable/IVariable.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Variable;
 
 public interface IVariable

--- a/libs/xSdk.Plugin/src/Extensions/Variable/IVariableService.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Variable/IVariableService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Concurrent;
 
 namespace xSdk.Extensions.Variable;

--- a/libs/xSdk.Plugin/src/Extensions/Variable/Providers/VariableProvider.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Variable/Providers/VariableProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Variable.Providers;
 
 public abstract class VariableProvider

--- a/libs/xSdk.Plugin/src/Extensions/Web/Authenticator.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Web/Authenticator.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using RestSharp.Authenticators;
 using xSdk.Hosting;
 using xSdk.Security;

--- a/libs/xSdk.Plugin/src/Extensions/Web/HttpClientBuilder.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Web/HttpClientBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Net.Http.Handlers;
 using NLog;
 using xSdk.Hosting;

--- a/libs/xSdk.Plugin/src/Extensions/Web/ProblemDetailsExtensions.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Web/ProblemDetailsExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 

--- a/libs/xSdk.Plugin/src/Extensions/Web/RestClientBuilder.cs
+++ b/libs/xSdk.Plugin/src/Extensions/Web/RestClientBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using NLog;
 using RestSharp;
 using RestSharp.Authenticators;

--- a/libs/xSdk.Plugin/src/Hosting/HostPluginBase.cs
+++ b/libs/xSdk.Plugin/src/Hosting/HostPluginBase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using xSdk.Extensions.Plugin;

--- a/libs/xSdk.Plugin/src/Hosting/ISlimHost.cs
+++ b/libs/xSdk.Plugin/src/Hosting/ISlimHost.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.IO;
 using xSdk.Extensions.Plugin;
 using xSdk.Extensions.Variable;

--- a/libs/xSdk.Plugin/src/Hosting/IWebHostSetup.cs
+++ b/libs/xSdk.Plugin/src/Hosting/IWebHostSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 
 namespace xSdk.Hosting;

--- a/libs/xSdk.Plugin/src/Hosting/PluginBase.cs
+++ b/libs/xSdk.Plugin/src/Hosting/PluginBase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.Plugin;
 

--- a/libs/xSdk.Plugin/src/Hosting/SlimHost.cs
+++ b/libs/xSdk.Plugin/src/Hosting/SlimHost.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Hosting;
 
 // Remarks: This SlimHost is only for Abstractions Library and should not be used in any other library.

--- a/libs/xSdk.Plugin/src/Hosting/SlimHostBase.cs
+++ b/libs/xSdk.Plugin/src/Hosting/SlimHostBase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.IO;
 using xSdk.Extensions.Plugin;

--- a/libs/xSdk.Plugin/src/Hosting/SlimHostBuilder.cs
+++ b/libs/xSdk.Plugin/src/Hosting/SlimHostBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 
 namespace xSdk.Hosting;

--- a/libs/xSdk.Plugin/src/Hosting/WebHostPluginBase.cs
+++ b/libs/xSdk.Plugin/src/Hosting/WebHostPluginBase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Routing;

--- a/libs/xSdk.Plugin/src/Plugins/Authentication/AuthenticationDefaults.cs
+++ b/libs/xSdk.Plugin/src/Plugins/Authentication/AuthenticationDefaults.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using AspNetCore.Authentication.ApiKey;
 
 namespace xSdk.Plugins.Authentication;

--- a/libs/xSdk.Plugin/src/Plugins/Authentication/IAuthenticationPluginBuilder.cs
+++ b/libs/xSdk.Plugin/src/Plugins/Authentication/IAuthenticationPluginBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;

--- a/libs/xSdk.Plugin/src/Plugins/DataProtection/IDataProtectionPluginBuilder.cs
+++ b/libs/xSdk.Plugin/src/Plugins/DataProtection/IDataProtectionPluginBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.DataProtection;
 using xSdk.Extensions.Plugin;
 

--- a/libs/xSdk.Plugin/src/Plugins/DataProtection/IDataProtectionSetup.cs
+++ b/libs/xSdk.Plugin/src/Plugins/DataProtection/IDataProtectionSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 
 namespace xSdk.Plugins.DataProtection;

--- a/libs/xSdk.Plugin/src/Plugins/Documentation/IDocumentationPluginBuilder.cs
+++ b/libs/xSdk.Plugin/src/Plugins/Documentation/IDocumentationPluginBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Asp.Versioning.ApiExplorer;
 using Microsoft.OpenApi;
 using xSdk.Extensions.Plugin;

--- a/libs/xSdk.Plugin/src/Plugins/Documentation/IDocumentationSetup.cs
+++ b/libs/xSdk.Plugin/src/Plugins/Documentation/IDocumentationSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 
 namespace xSdk.Plugins.Documentation;

--- a/libs/xSdk.Plugin/src/Plugins/WebApi/IWebApiPluginBuilder.cs
+++ b/libs/xSdk.Plugin/src/Plugins/WebApi/IWebApiPluginBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Mvc;
 using xSdk.Extensions.Plugin;
 

--- a/libs/xSdk.Plugin/src/Plugins/WebSecurity/IWebSecurityPluginBuilder.cs
+++ b/libs/xSdk.Plugin/src/Plugins/WebSecurity/IWebSecurityPluginBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Plugin;
 
 namespace xSdk.Plugins.WebSecurity;

--- a/libs/xSdk.Plugin/src/Plugins/WebSecurity/IWebSecuritySetup.cs
+++ b/libs/xSdk.Plugin/src/Plugins/WebSecurity/IWebSecuritySetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 
 namespace xSdk.Plugins.WebSecurity;

--- a/libs/xSdk.Plugin/src/SdkException.cs
+++ b/libs/xSdk.Plugin/src/SdkException.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Runtime.Serialization;
 
 namespace xSdk;

--- a/libs/xSdk.Plugin/src/Security/Claims/Authority.cs
+++ b/libs/xSdk.Plugin/src/Security/Claims/Authority.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/libs/xSdk.Plugin/src/Security/Claims/ClaimCreator.cs
+++ b/libs/xSdk.Plugin/src/Security/Claims/ClaimCreator.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Claims;
 using xSdk.Hosting;
 

--- a/libs/xSdk.Plugin/src/Security/Claims/ClaimModel.cs
+++ b/libs/xSdk.Plugin/src/Security/Claims/ClaimModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Security.Claims;
 
 public sealed class ClaimModel

--- a/libs/xSdk.Plugin/src/Security/Claims/ClaimModelExtensions.cs
+++ b/libs/xSdk.Plugin/src/Security/Claims/ClaimModelExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/libs/xSdk.Plugin/src/Security/Claims/SdkClaimTypes.cs
+++ b/libs/xSdk.Plugin/src/Security/Claims/SdkClaimTypes.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/libs/xSdk.Plugin/src/Security/CredentialManager.cs
+++ b/libs/xSdk.Plugin/src/Security/CredentialManager.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using NLog;
 using xSdk.Hosting;
 

--- a/libs/xSdk.Plugin/src/Security/Credentials.cs
+++ b/libs/xSdk.Plugin/src/Security/Credentials.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Security;
 
 public abstract class Credentials

--- a/libs/xSdk.Plugin/src/Security/CryptoTool.cs
+++ b/libs/xSdk.Plugin/src/Security/CryptoTool.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;

--- a/libs/xSdk.Plugin/src/Security/SecurityContext.cs
+++ b/libs/xSdk.Plugin/src/Security/SecurityContext.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 

--- a/libs/xSdk.Plugin/src/SemVer.cs
+++ b/libs/xSdk.Plugin/src/SemVer.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json.Serialization;
 using xSdk.Shared;
 

--- a/libs/xSdk.Plugin/src/Shared/AtributeExtensions.cs
+++ b/libs/xSdk.Plugin/src/Shared/AtributeExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 
 namespace xSdk.Shared;

--- a/libs/xSdk.Plugin/src/Shared/Base64Helper.cs
+++ b/libs/xSdk.Plugin/src/Shared/Base64Helper.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text;
 
 namespace xSdk.Shared;

--- a/libs/xSdk.Plugin/src/Shared/CertificateHelper.cs
+++ b/libs/xSdk.Plugin/src/Shared/CertificateHelper.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;

--- a/libs/xSdk.Plugin/src/Shared/DictionaryExtensions.cs
+++ b/libs/xSdk.Plugin/src/Shared/DictionaryExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Shared;
 
 public static class DictionaryExtensions

--- a/libs/xSdk.Plugin/src/Shared/EmbeddedResourceLoader.cs
+++ b/libs/xSdk.Plugin/src/Shared/EmbeddedResourceLoader.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 using NLog;
 

--- a/libs/xSdk.Plugin/src/Shared/EnvironmentTools.cs
+++ b/libs/xSdk.Plugin/src/Shared/EnvironmentTools.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Shared;
 
 public static class EnvironmentTools

--- a/libs/xSdk.Plugin/src/Shared/HashTools.cs
+++ b/libs/xSdk.Plugin/src/Shared/HashTools.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Cryptography;
 using System.Text;
 

--- a/libs/xSdk.Plugin/src/Shared/NetworkTools.cs
+++ b/libs/xSdk.Plugin/src/Shared/NetworkTools.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;

--- a/libs/xSdk.Plugin/src/Shared/ObjectHelper.cs
+++ b/libs/xSdk.Plugin/src/Shared/ObjectHelper.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Shared;
 
 public static class ObjectHelper

--- a/libs/xSdk.Plugin/src/Shared/StringHelper.cs
+++ b/libs/xSdk.Plugin/src/Shared/StringHelper.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text;
 
 namespace xSdk.Shared;

--- a/libs/xSdk.Plugin/src/Shared/TimeSpanParser.cs
+++ b/libs/xSdk.Plugin/src/Shared/TimeSpanParser.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Globalization;
 
 namespace xSdk.Shared;

--- a/libs/xSdk.Plugin/src/Shared/TypeConverter.cs
+++ b/libs/xSdk.Plugin/src/Shared/TypeConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Globalization;
 using Newtonsoft.Json.Linq;
 

--- a/libs/xSdk.Plugin/src/Stage.cs
+++ b/libs/xSdk.Plugin/src/Stage.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk;
 
 [Flags]

--- a/libs/xSdk.Plugin/tests/Data/Annotations/DataAnnotationAttributeTests.cs
+++ b/libs/xSdk.Plugin/tests/Data/Annotations/DataAnnotationAttributeTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations;
 using xSdk.Data.Annotations;
 

--- a/libs/xSdk.Plugin/tests/Data/Converters/Json/DateTimeConverterTests.cs
+++ b/libs/xSdk.Plugin/tests/Data/Converters/Json/DateTimeConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using xSdk.Data.Converters.Json;
 

--- a/libs/xSdk.Plugin/tests/Data/Converters/Json/SemVerJsonConverterTests.cs
+++ b/libs/xSdk.Plugin/tests/Data/Converters/Json/SemVerJsonConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using xSdk;
 using xSdk.Data.Converters.Json;

--- a/libs/xSdk.Plugin/tests/Data/Converters/Json/StageConverterTests.cs
+++ b/libs/xSdk.Plugin/tests/Data/Converters/Json/StageConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using xSdk.Data.Converters.Json;
 

--- a/libs/xSdk.Plugin/tests/Data/Converters/Json/VersionConverterTests.cs
+++ b/libs/xSdk.Plugin/tests/Data/Converters/Json/VersionConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using xSdk.Data.Converters.Json;
 

--- a/libs/xSdk.Plugin/tests/Data/Converters/Mapper/GuidConverterTests.cs
+++ b/libs/xSdk.Plugin/tests/Data/Converters/Mapper/GuidConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data.Converters.Mapper;
 
 namespace xSdk.Plugin.Tests.Data.Converters.Mapper;

--- a/libs/xSdk.Plugin/tests/Data/GuidStringPKTests.cs
+++ b/libs/xSdk.Plugin/tests/Data/GuidStringPKTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data;
 
 public class GuidStringPKTests

--- a/libs/xSdk.Plugin/tests/Data/JsonHelperTests.cs
+++ b/libs/xSdk.Plugin/tests/Data/JsonHelperTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using xSdk.Data;
 

--- a/libs/xSdk.Plugin/tests/Data/PrimaryKeyTests.cs
+++ b/libs/xSdk.Plugin/tests/Data/PrimaryKeyTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Plugin.Tests.Data;

--- a/libs/xSdk.Plugin/tests/Extensions/Authentication/ApiKeySignatureTests.cs
+++ b/libs/xSdk.Plugin/tests/Extensions/Authentication/ApiKeySignatureTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Authentication;
 
 namespace xSdk.Plugin.Tests.Extensions.Authentication;

--- a/libs/xSdk.Plugin/tests/Extensions/Authentication/ClaimsPrincipalExtensionsTests.cs
+++ b/libs/xSdk.Plugin/tests/Extensions/Authentication/ClaimsPrincipalExtensionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Claims;
 using xSdk.Extensions.Authentication;
 using xSdk.Security.Claims;

--- a/libs/xSdk.Plugin/tests/Extensions/Authentication/ConcreteApiKeyTests.cs
+++ b/libs/xSdk.Plugin/tests/Extensions/Authentication/ConcreteApiKeyTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Claims;
 using xSdk.Extensions.Authentication;
 

--- a/libs/xSdk.Plugin/tests/Extensions/Commands/CommandlineParserTests.cs
+++ b/libs/xSdk.Plugin/tests/Extensions/Commands/CommandlineParserTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Commands;
 
 namespace xSdk.Plugin.Tests.Extensions.Commands;

--- a/libs/xSdk.Plugin/tests/Extensions/IO/FileSystemHelperTests.cs
+++ b/libs/xSdk.Plugin/tests/Extensions/IO/FileSystemHelperTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.IO;
 
 namespace xSdk.Plugin.Tests.Extensions.IO;

--- a/libs/xSdk.Plugin/tests/Extensions/Variable/Attributes/VariableAttributeTests.cs
+++ b/libs/xSdk.Plugin/tests/Extensions/Variable/Attributes/VariableAttributeTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable.Attributes;
 
 namespace xSdk.Plugin.Tests.Extensions.Variable.Attributes;

--- a/libs/xSdk.Plugin/tests/Extensions/Web/ProblemDetailsExtensionsTests.cs
+++ b/libs/xSdk.Plugin/tests/Extensions/Web/ProblemDetailsExtensionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;

--- a/libs/xSdk.Plugin/tests/SdkExceptionTests.cs
+++ b/libs/xSdk.Plugin/tests/SdkExceptionTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Plugin.Tests;
 
 public class SdkExceptionTests

--- a/libs/xSdk.Plugin/tests/Security/Claims/AuthorityTests.cs
+++ b/libs/xSdk.Plugin/tests/Security/Claims/AuthorityTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Security.Claims;
 
 namespace xSdk.Plugin.Tests.Security.Claims;

--- a/libs/xSdk.Plugin/tests/Security/Claims/ClaimCreatorTests.cs
+++ b/libs/xSdk.Plugin/tests/Security/Claims/ClaimCreatorTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Claims;
 using xSdk.Security.Claims;
 

--- a/libs/xSdk.Plugin/tests/Security/Claims/ClaimModelTests.cs
+++ b/libs/xSdk.Plugin/tests/Security/Claims/ClaimModelTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Security.Claims;
 using xSdk.Security.Claims;
 

--- a/libs/xSdk.Plugin/tests/Security/CredentialManagerTests.cs
+++ b/libs/xSdk.Plugin/tests/Security/CredentialManagerTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Security;
 
 namespace xSdk.Plugin.Tests.Security;

--- a/libs/xSdk.Plugin/tests/Security/CryptoToolTests.cs
+++ b/libs/xSdk.Plugin/tests/Security/CryptoToolTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Security;
 
 namespace xSdk.Plugin.Tests.Security;

--- a/libs/xSdk.Plugin/tests/Security/SecurityContextTests.cs
+++ b/libs/xSdk.Plugin/tests/Security/SecurityContextTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Security;
 
 namespace xSdk.Plugin.Tests.Security;

--- a/libs/xSdk.Plugin/tests/SemVerTests.cs
+++ b/libs/xSdk.Plugin/tests/SemVerTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Plugin.Tests;
 
 public class SemVerTests

--- a/libs/xSdk.Plugin/tests/Shared/AtributeExtensionsTests.cs
+++ b/libs/xSdk.Plugin/tests/Shared/AtributeExtensionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 using xSdk.Shared;
 

--- a/libs/xSdk.Plugin/tests/Shared/Base64HelperTests.cs
+++ b/libs/xSdk.Plugin/tests/Shared/Base64HelperTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text;
 using xSdk.Shared;
 

--- a/libs/xSdk.Plugin/tests/Shared/DictionaryExtensionsTests.cs
+++ b/libs/xSdk.Plugin/tests/Shared/DictionaryExtensionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Plugin.Tests.Shared;

--- a/libs/xSdk.Plugin/tests/Shared/EmbeddedResourceLoaderTests.cs
+++ b/libs/xSdk.Plugin/tests/Shared/EmbeddedResourceLoaderTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 using xSdk.Shared;
 

--- a/libs/xSdk.Plugin/tests/Shared/EnvironmentToolsTests.cs
+++ b/libs/xSdk.Plugin/tests/Shared/EnvironmentToolsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Plugin.Tests.Shared;

--- a/libs/xSdk.Plugin/tests/Shared/HashToolsTests.cs
+++ b/libs/xSdk.Plugin/tests/Shared/HashToolsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Plugin.Tests.Shared;

--- a/libs/xSdk.Plugin/tests/Shared/NetworkToolsTests.cs
+++ b/libs/xSdk.Plugin/tests/Shared/NetworkToolsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Plugin.Tests.Shared;

--- a/libs/xSdk.Plugin/tests/Shared/ObjectHelperTests.cs
+++ b/libs/xSdk.Plugin/tests/Shared/ObjectHelperTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Plugin.Tests.Shared;

--- a/libs/xSdk.Plugin/tests/Shared/StringHelperTests.cs
+++ b/libs/xSdk.Plugin/tests/Shared/StringHelperTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Plugin.Tests.Shared;

--- a/libs/xSdk.Plugin/tests/Shared/TimeSpanParserTests.cs
+++ b/libs/xSdk.Plugin/tests/Shared/TimeSpanParserTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Plugin.Tests.Shared;

--- a/libs/xSdk.Plugin/tests/Shared/TypeConverterTests.cs
+++ b/libs/xSdk.Plugin/tests/Shared/TypeConverterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Plugin.Tests.Shared;

--- a/libs/xSdk.Plugin/tests/StageTests.cs
+++ b/libs/xSdk.Plugin/tests/StageTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Plugin.Tests;
 
 public class StageTests

--- a/libs/xSdk/src/Extensions/IO/FileSystemService.cs
+++ b/libs/xSdk/src/Extensions/IO/FileSystemService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Runtime.InteropServices;
 using NLog;
 using xSdk.Extensions.Variable;

--- a/libs/xSdk/src/Extensions/IO/InternalFileSystemResult.cs
+++ b/libs/xSdk/src/Extensions/IO/InternalFileSystemResult.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Zio;
 
 namespace xSdk.Extensions.IO;

--- a/libs/xSdk/src/Extensions/IO/RootFolders.cs
+++ b/libs/xSdk/src/Extensions/IO/RootFolders.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Zio;
 
 namespace xSdk.Extensions.IO;

--- a/libs/xSdk/src/Extensions/IO/ServiceCollectionExtensions.cs
+++ b/libs/xSdk/src/Extensions/IO/ServiceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using xSdk.Hosting;

--- a/libs/xSdk/src/Extensions/Plugin/CatalogHelper.cs
+++ b/libs/xSdk/src/Extensions/Plugin/CatalogHelper.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 using Weikio.PluginFramework.Abstractions;
 using Weikio.PluginFramework.Catalogs;

--- a/libs/xSdk/src/Extensions/Plugin/Commands/InstallCommand.cs
+++ b/libs/xSdk/src/Extensions/Plugin/Commands/InstallCommand.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Plugin.Commands;
 
 internal class InstallCommand { }

--- a/libs/xSdk/src/Extensions/Plugin/Commands/UninstallCommand.cs
+++ b/libs/xSdk/src/Extensions/Plugin/Commands/UninstallCommand.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Plugin.Commands;
 
 internal class UninstallCommand { }

--- a/libs/xSdk/src/Extensions/Plugin/PluginItem.cs
+++ b/libs/xSdk/src/Extensions/Plugin/PluginItem.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using NLog;
 using xSdk.Shared;
 

--- a/libs/xSdk/src/Extensions/Plugin/PluginService.AddRemove.cs
+++ b/libs/xSdk/src/Extensions/Plugin/PluginService.AddRemove.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 using xSdk.Shared;
 

--- a/libs/xSdk/src/Extensions/Plugin/PluginService.Catalog.cs
+++ b/libs/xSdk/src/Extensions/Plugin/PluginService.Catalog.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Weikio.PluginFramework.Catalogs;

--- a/libs/xSdk/src/Extensions/Plugin/PluginService.cs
+++ b/libs/xSdk/src/Extensions/Plugin/PluginService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Logging;
 using xSdk.Extensions.IO;
 

--- a/libs/xSdk/src/Extensions/Plugin/ServiceCollectionExtensions.cs
+++ b/libs/xSdk/src/Extensions/Plugin/ServiceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using xSdk.Hosting;

--- a/libs/xSdk/src/Extensions/Variable/Commands/CommandsExtensions.cs
+++ b/libs/xSdk/src/Extensions/Variable/Commands/CommandsExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Spectre.Console.Cli;
 
 namespace xSdk.Extensions.Variable.Commands;

--- a/libs/xSdk/src/Extensions/Variable/Commands/ListCommand.cs
+++ b/libs/xSdk/src/Extensions/Variable/Commands/ListCommand.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;

--- a/libs/xSdk/src/Extensions/Variable/Commands/ListCommandSettings.cs
+++ b/libs/xSdk/src/Extensions/Variable/Commands/ListCommandSettings.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel;
 using Spectre.Console.Cli;
 

--- a/libs/xSdk/src/Extensions/Variable/EnvironmentSetup.Definitions.cs
+++ b/libs/xSdk/src/Extensions/Variable/EnvironmentSetup.Definitions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Variable;
 
 public sealed partial class EnvironmentSetup

--- a/libs/xSdk/src/Extensions/Variable/EnvironmentSetup.Service.cs
+++ b/libs/xSdk/src/Extensions/Variable/EnvironmentSetup.Service.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Reflection;
 using xSdk.Extensions.Variable.Attributes;
 

--- a/libs/xSdk/src/Extensions/Variable/EnvironmentSetup.System.cs
+++ b/libs/xSdk/src/Extensions/Variable/EnvironmentSetup.System.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using xSdk.Extensions.Variable.Attributes;

--- a/libs/xSdk/src/Extensions/Variable/EnvironmentSetup.cs
+++ b/libs/xSdk/src/Extensions/Variable/EnvironmentSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Commands;
 using xSdk.Extensions.Variable.Attributes;
 

--- a/libs/xSdk/src/Extensions/Variable/EnvironmentSetupExtensions.cs
+++ b/libs/xSdk/src/Extensions/Variable/EnvironmentSetupExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using xSdk.Extensions.Commands;

--- a/libs/xSdk/src/Extensions/Variable/Globals.cs
+++ b/libs/xSdk/src/Extensions/Variable/Globals.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Variable;
 
 internal static class Globals

--- a/libs/xSdk/src/Extensions/Variable/Providers/CommandlineProvider.cs
+++ b/libs/xSdk/src/Extensions/Variable/Providers/CommandlineProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Commands;
 
 namespace xSdk.Extensions.Variable.Providers;

--- a/libs/xSdk/src/Extensions/Variable/Providers/FallbackProvider.cs
+++ b/libs/xSdk/src/Extensions/Variable/Providers/FallbackProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Runtime.InteropServices;
 using xSdk.Hosting;
 

--- a/libs/xSdk/src/Extensions/Variable/Providers/FileProvider.cs
+++ b/libs/xSdk/src/Extensions/Variable/Providers/FileProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Extensions.Variable.Providers;

--- a/libs/xSdk/src/Extensions/Variable/Providers/MemoryProvider.cs
+++ b/libs/xSdk/src/Extensions/Variable/Providers/MemoryProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Concurrent;
 using xSdk.Shared;
 

--- a/libs/xSdk/src/Extensions/Variable/Providers/OptionProvider.cs
+++ b/libs/xSdk/src/Extensions/Variable/Providers/OptionProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Configuration;
 using xSdk.Hosting;
 

--- a/libs/xSdk/src/Extensions/Variable/Providers/SystemProvider.cs
+++ b/libs/xSdk/src/Extensions/Variable/Providers/SystemProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Extensions.Variable.Providers;

--- a/libs/xSdk/src/Extensions/Variable/Providers/VariableProviderBase.cs
+++ b/libs/xSdk/src/Extensions/Variable/Providers/VariableProviderBase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Variable.Providers;
 
 internal abstract class VariableProviderBase : VariableProvider

--- a/libs/xSdk/src/Extensions/Variable/SerivceCollectionExtensions.cs
+++ b/libs/xSdk/src/Extensions/Variable/SerivceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/libs/xSdk/src/Extensions/Variable/Setup.cs
+++ b/libs/xSdk/src/Extensions/Variable/Setup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;

--- a/libs/xSdk/src/Extensions/Variable/SetupExtensions.cs
+++ b/libs/xSdk/src/Extensions/Variable/SetupExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
 using NLog;

--- a/libs/xSdk/src/Extensions/Variable/Variable.cs
+++ b/libs/xSdk/src/Extensions/Variable/Variable.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable.Attributes;
 using xSdk.Hosting;
 using xSdk.Shared;

--- a/libs/xSdk/src/Extensions/Variable/VariableExtensions.cs
+++ b/libs/xSdk/src/Extensions/Variable/VariableExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable.Attributes;
 
 namespace xSdk.Extensions.Variable;

--- a/libs/xSdk/src/Extensions/Variable/VariableRegistration.cs
+++ b/libs/xSdk/src/Extensions/Variable/VariableRegistration.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Variable;
 
 internal class VariableRegistration

--- a/libs/xSdk/src/Extensions/Variable/VariableService.Handler.cs
+++ b/libs/xSdk/src/Extensions/Variable/VariableService.Handler.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Concurrent;
 using xSdk.Extensions.Variable.Providers;
 

--- a/libs/xSdk/src/Extensions/Variable/VariableService.Provider.cs
+++ b/libs/xSdk/src/Extensions/Variable/VariableService.Provider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Concurrent;
 using xSdk.Extensions.Variable.Providers;
 using xSdk.Shared;

--- a/libs/xSdk/src/Extensions/Variable/VariableService.Resources.cs
+++ b/libs/xSdk/src/Extensions/Variable/VariableService.Resources.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Shared;
 
 namespace xSdk.Extensions.Variable;

--- a/libs/xSdk/src/Extensions/Variable/VariableService.Setups.cs
+++ b/libs/xSdk/src/Extensions/Variable/VariableService.Setups.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Concurrent;
 using xSdk.Shared;
 

--- a/libs/xSdk/src/Extensions/Variable/VariableService.cs
+++ b/libs/xSdk/src/Extensions/Variable/VariableService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections;
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Configuration;

--- a/libs/xSdk/src/Extensions/Variable/VariableServiceSetup.cs
+++ b/libs/xSdk/src/Extensions/Variable/VariableServiceSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Variable;
 
 public sealed class VariableServiceSetup

--- a/libs/xSdk/src/Extensions/Variable/VariableServiceSetupExtensions.cs
+++ b/libs/xSdk/src/Extensions/Variable/VariableServiceSetupExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable.Providers;
 
 namespace xSdk.Extensions.Variable;

--- a/libs/xSdk/src/Hosting/Host.cs
+++ b/libs/xSdk/src/Hosting/Host.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NLog;

--- a/libs/xSdk/src/Hosting/HostBuilderExtensions.cs
+++ b/libs/xSdk/src/Hosting/HostBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Hosting;
 using xSdk.Extensions.Plugin;
 using xSdk.Extensions.Variable;

--- a/libs/xSdk/src/Hosting/HostConfigurationManager.cs
+++ b/libs/xSdk/src/Hosting/HostConfigurationManager.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;

--- a/libs/xSdk/src/Hosting/HostLoggingManager.cs
+++ b/libs/xSdk/src/Hosting/HostLoggingManager.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Diagnostics;
 using System.Text;
 using Microsoft.Extensions.Logging;

--- a/libs/xSdk/src/Hosting/SlimHost.cs
+++ b/libs/xSdk/src/Hosting/SlimHost.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Hosting;
 
 public sealed class SlimHost

--- a/libs/xSdk/src/Hosting/SlimHostInternal.cs
+++ b/libs/xSdk/src/Hosting/SlimHostInternal.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.IO;

--- a/libs/xSdk/src/Hosting/TestHost.cs
+++ b/libs/xSdk/src/Hosting/TestHost.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NLog;

--- a/libs/xSdk/src/Hosting/TestHostFixture.cs
+++ b/libs/xSdk/src/Hosting/TestHostFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/libs/xSdk/src/Hosting/TestRunnerDetection.cs
+++ b/libs/xSdk/src/Hosting/TestRunnerDetection.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Hosting;
 
 public static class TestRunnerDetection

--- a/libs/xSdk/tests/Data/Mocks/TestModel.cs
+++ b/libs/xSdk/tests/Data/Mocks/TestModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data.Mocks;
 
 public class TestModel : Model

--- a/libs/xSdk/tests/Data/Mocks/TestModelValidation.cs
+++ b/libs/xSdk/tests/Data/Mocks/TestModelValidation.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using FluentValidation;
 
 namespace xSdk.Data.Mocks;

--- a/libs/xSdk/tests/Data/ModelWithAdditionalDataTests.cs
+++ b/libs/xSdk/tests/Data/ModelWithAdditionalDataTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json;
 using xSdk.Data.Mocks;
 

--- a/libs/xSdk/tests/Extensions/Authentication/ApiKeyModelExtensionsTests.cs
+++ b/libs/xSdk/tests/Extensions/Authentication/ApiKeyModelExtensionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 using xSdk.Security.Claims;
 

--- a/libs/xSdk/tests/Extensions/IO/FileSystemServiceTests.cs
+++ b/libs/xSdk/tests/Extensions/IO/FileSystemServiceTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Hosting;
 
 namespace xSdk.Extensions.IO;

--- a/libs/xSdk/tests/Extensions/Plugin/PluginServiceTests.cs
+++ b/libs/xSdk/tests/Extensions/Plugin/PluginServiceTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Hosting;
 
 namespace xSdk.Extensions.Plugin;

--- a/libs/xSdk/tests/Extensions/Variable/EnableDisableDemoModeTests.cs
+++ b/libs/xSdk/tests/Extensions/Variable/EnableDisableDemoModeTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Hosting;
 
 namespace xSdk.Extensions.Variable;

--- a/libs/xSdk/tests/Extensions/Variable/EnvironmentSetupTests.cs
+++ b/libs/xSdk/tests/Extensions/Variable/EnvironmentSetupTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Variable;
 
 public class EnvironmentSetupTests

--- a/libs/xSdk/tests/Extensions/Variable/Fakes/SetupWithNoPrefix.cs
+++ b/libs/xSdk/tests/Extensions/Variable/Fakes/SetupWithNoPrefix.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable.Attributes;
 
 namespace xSdk.Extensions.Variable.Fakes;

--- a/libs/xSdk/tests/Extensions/Variable/Fakes/TestVariableProvider.cs
+++ b/libs/xSdk/tests/Extensions/Variable/Fakes/TestVariableProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable.Providers;
 
 namespace xSdk.Extensions.Variable.Fakes;

--- a/libs/xSdk/tests/Extensions/Variable/SetupExtensionsTests.cs
+++ b/libs/xSdk/tests/Extensions/Variable/SetupExtensionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Hosting;
 
 namespace xSdk.Extensions.Variable;

--- a/libs/xSdk/tests/Extensions/Variable/SetupTests.cs
+++ b/libs/xSdk/tests/Extensions/Variable/SetupTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Hosting;
 
 namespace xSdk.Extensions.Variable;

--- a/libs/xSdk/tests/Extensions/Variable/VariableProviderTests.cs
+++ b/libs/xSdk/tests/Extensions/Variable/VariableProviderTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable.Fakes;
 using xSdk.Hosting;
 

--- a/libs/xSdk/tests/Extensions/Variable/VariableServiceTests.cs
+++ b/libs/xSdk/tests/Extensions/Variable/VariableServiceTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable.Fakes;
 using xSdk.Hosting;
 

--- a/libs/xSdk/tests/Extensions/Variable/VariableTests.cs
+++ b/libs/xSdk/tests/Extensions/Variable/VariableTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Hosting;
 
 namespace xSdk.Extensions.Variable;

--- a/libs/xSdk/tests/Hosting/HostTests.cs
+++ b/libs/xSdk/tests/Hosting/HostTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Hosting;
 
 public class HostTests

--- a/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulConnectionBuilder.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulConnectionBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using Consul;
 

--- a/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulDatabase.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulDatabase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using Consul;
 using Microsoft.Extensions.Logging;

--- a/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulDatabaseSetup.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulDatabaseSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using xSdk.Extensions.Variable;
 

--- a/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulEntity.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulEntity.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data
 {
     public class ConsulEntity : Entity, IEntity<ConsulPrimaryKey, string>

--- a/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulPrimaryKey.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulPrimaryKey.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulRepository.Insert.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulRepository.Insert.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulRepository.Remove.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulRepository.Remove.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulRepository.Select.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulRepository.Select.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulRepository.Update.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulRepository.Update.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulRepository.Upsert.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulRepository.Upsert.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulRepository.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Data/ConsulRepository.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text;
 using Consul;
 

--- a/think-tank/libs/xSdk.Data.Consul/src/Data/ServiceCollectionExtensions.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Data/ServiceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 
 namespace xSdk.Data

--- a/think-tank/libs/xSdk.Data.Consul/src/Extensions/Consul/ConsulService.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Extensions/Consul/ConsulService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Net;
 using System.Threading;

--- a/think-tank/libs/xSdk.Data.Consul/src/Extensions/Consul/ConsulServiceOld.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Extensions/Consul/ConsulServiceOld.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //using Consul;
 //using xSdk.Configuration;
 //using Microsoft.Extensions.Configuration;

--- a/think-tank/libs/xSdk.Data.Consul/src/Extensions/Consul/IConsulService.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Extensions/Consul/IConsulService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/think-tank/libs/xSdk.Data.Consul/src/Extensions/Consul/ServiceCollectionExtensions.cs
+++ b/think-tank/libs/xSdk.Data.Consul/src/Extensions/Consul/ServiceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Choice.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Choice.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Composition.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Composition.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 
 namespace xSdk.Extensions.Mermaid.Data

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Description.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Description.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Diagram.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Diagram.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Data;
 
 namespace xSdk.Extensions.Mermaid.Data

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Fork.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Fork.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 
 namespace xSdk.Extensions.Mermaid.Data

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/ISupportComments.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/ISupportComments.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Mermaid.Data
 {
     public interface ISupportComments

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/ISupportName.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/ISupportName.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Join.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Join.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Mermaid.Data
 {
     internal sealed class Join : ISupportName, ISupportComments

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/State.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/State.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using xSdk.Data;
 

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/StateDiagram.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/StateDiagram.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 
 namespace xSdk.Extensions.Mermaid.Data

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Transition.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Data/Transition.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 
 namespace xSdk.Extensions.Mermaid.Data

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/DiagramType.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/DiagramType.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/IMermaidService.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/IMermaidService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Mermaid.Data;
 
 namespace xSdk.Extensions.Mermaid

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/ILexerService.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/ILexerService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 
 namespace xSdk.Extensions.Mermaid.Lexer

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/LexerService.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/LexerService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/StateDiagramTokenizer.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/StateDiagramTokenizer.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 
 namespace xSdk.Extensions.Mermaid.Lexer

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/Token.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/Token.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 
 namespace xSdk.Extensions.Mermaid.Lexer

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/TokenDefinition.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/TokenDefinition.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Mermaid.Lexer
 {
     public sealed class TokenDefinition

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/TokenDefinitionExtensions.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/TokenDefinitionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/TokenExtensions.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/TokenExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/TokenMatch.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/TokenMatch.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Mermaid.Lexer
 {
     internal class TokenMatch

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/TokenizerBase.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Lexer/TokenizerBase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Linq;
 

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/MermaidService.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/MermaidService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Logging;
 using xSdk.Extensions.Mermaid.Data;
 using xSdk.Extensions.Mermaid.Lexer;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/IParserService.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/IParserService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using xSdk.Extensions.Mermaid.Data;
 using xSdk.Extensions.Mermaid.Lexer;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/ParserBase.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/ParserBase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using xSdk.Extensions.Mermaid.Data;
 using xSdk.Extensions.Mermaid.Lexer;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/ParserService.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/ParserService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using xSdk.Extensions.Mermaid.Data;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/StateDiagramParser.Build.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/StateDiagramParser.Build.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Linq;
 using xSdk.Extensions.Mermaid.Data;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/StateDiagramParser.Parsing.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/StateDiagramParser.Parsing.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using xSdk.Extensions.Mermaid.Data;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/StateDiagramParser.Search.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/StateDiagramParser.Search.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Linq;
 using xSdk.Extensions.Mermaid.Data;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/StateDiagramParser.Validation.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/StateDiagramParser.Validation.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Linq;
 using xSdk.Extensions.Mermaid.Data;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/StateDiagramParser.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/Parser/StateDiagramParser.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/ServiceCollectionExtensions.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/ServiceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.Mermaid.Lexer;
 using xSdk.Extensions.Mermaid.Parser;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/StateDiagramMarks.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/StateDiagramMarks.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Mermaid/src/StateDiagramNames.cs
+++ b/think-tank/libs/xSdk.Extensions.Mermaid/src/StateDiagramNames.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Mermaid
 {
     internal static class StateDiagramNames

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/ArtifactModel.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/ArtifactModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/ArtifactModelList.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/ArtifactModelList.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using RestSharp;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/Artifactory.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/Artifactory.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/AutomationHub.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/AutomationHub.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/AutomationRuntime.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/AutomationRuntime.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/Converters/Json/TemplateLanguageConverter.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/Converters/Json/TemplateLanguageConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/Converters/Json/TemplateTypeConverter.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/Converters/Json/TemplateTypeConverter.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/Dependencies.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/Dependencies.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/DependenciesExtensions.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/DependenciesExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/DevelopmentKit.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/DevelopmentKit.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json.Serialization;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/PackageModel.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/PackageModel.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/PackageType.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/PackageType.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data
 {
     public enum PackageType

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/Release.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/Release.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data
 {
     public class Release

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/ReleaseInfo.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/ReleaseInfo.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/Template.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/Template.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Text.Json.Serialization;
 
 namespace xSdk.Data

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/TemplateLanguage.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/TemplateLanguage.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data
 {
     public enum TemplateLanguage

--- a/think-tank/libs/xSdk.Extensions.Package/src/Data/TemplateType.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Data/TemplateType.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Data
 {
     public enum TemplateType

--- a/think-tank/libs/xSdk.Extensions.Package/src/Globals.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Globals.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/HostExtensions.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/HostExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/IPackageJsonHandler.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/IPackageJsonHandler.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Threading;
 using System.Threading.Tasks;
 using xSdk.Data;

--- a/think-tank/libs/xSdk.Extensions.Package/src/IPackageProvider.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/IPackageProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/IPackageService.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/IPackageService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Versioning;

--- a/think-tank/libs/xSdk.Extensions.Package/src/IPackageServiceBuilder.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/IPackageServiceBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/IStore.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/IStore.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using NuGet.Versioning;
 using Sewer56.Update.Structures;
 using xSdk.Data;

--- a/think-tank/libs/xSdk.Extensions.Package/src/IStoreResolver.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/IStoreResolver.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Sewer56.Update.Interfaces;
 
 namespace xSdk.Extensions.Package

--- a/think-tank/libs/xSdk.Extensions.Package/src/IUpdateService.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/IUpdateService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/IUpdateServiceBuilder.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/IUpdateServiceBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/PackageCredentials.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/PackageCredentials.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // using xSdk.Security;
 
 // namespace xSdk.Extensions.Package

--- a/think-tank/libs/xSdk.Extensions.Package/src/PackageJsonHandler.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/PackageJsonHandler.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // using Microsoft.Extensions.Logging;
 // using System.Text.Json;
 // using xSdk.Data;

--- a/think-tank/libs/xSdk.Extensions.Package/src/PackageService.Build.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/PackageService.Build.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //using Microsoft.Extensions.Logging;
 //using System.Text.Json;
 //using System.Text.RegularExpressions;

--- a/think-tank/libs/xSdk.Extensions.Package/src/PackageService.Compact.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/PackageService.Compact.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // using xSdk.Data;
 // using Microsoft.Extensions.Logging;
 // using Sewer56.Update.Packaging;

--- a/think-tank/libs/xSdk.Extensions.Package/src/PackageService.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/PackageService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // using Microsoft.Extensions.Logging;
 // using NuGet.Versioning;
 // using xSdk.Data;

--- a/think-tank/libs/xSdk.Extensions.Package/src/PackageSetup.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/PackageSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.Variable;
 using xSdk.Extensions.Variable.Attributes;
 

--- a/think-tank/libs/xSdk.Extensions.Package/src/PluginExtensions.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/PluginExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Providers/Artifactory/ArtifacotryCredentials.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Providers/Artifactory/ArtifacotryCredentials.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Providers/Artifactory/ArtifactoryResolver.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Providers/Artifactory/ArtifactoryResolver.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using NuGet.Versioning;
 using Sewer56.Update.Interfaces;
 using Sewer56.Update.Packaging.Structures;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Providers/GitHub/GitHubProvider.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Providers/GitHub/GitHubProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Providers/GitHub/GitHubSetup.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Providers/GitHub/GitHubSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Providers/Gitea/GiteaProvider.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Providers/Gitea/GiteaProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Providers/Local/LocalProvider.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Providers/Local/LocalProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Sewer56.Update.Interfaces;
 using Sewer56.Update.Resolvers;
 using Sewer56.Update.Structures;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Providers/Local/LocalSetup.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Providers/Local/LocalSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using xSdk.Extensions.IO;
 using xSdk.Extensions.Variable;
 using xSdk.Extensions.Variable.Attributes;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Providers/Nuget/NugetPackageProvider.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Providers/Nuget/NugetPackageProvider.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Providers/Nuget/NugetSetup.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Providers/Nuget/NugetSetup.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/think-tank/libs/xSdk.Extensions.Package/src/ServiceCollectionExtensions.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/ServiceCollectionExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Stores/AbstractStore.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Stores/AbstractStore.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //using Microsoft.Extensions.Logging;
 //using NuGet.Versioning;
 //using Sewer56.Update;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Stores/Artifactory/ArtifactoryManager.Download.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Stores/Artifactory/ArtifactoryManager.Download.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //using xSdk.Data;
 //using xSdk.Shared;
 //using Microsoft.Extensions.Logging;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Stores/Artifactory/ArtifactoryManager.Search.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Stores/Artifactory/ArtifactoryManager.Search.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //using xSdk.Data;
 //using xSdk.Extensions.Web;
 //using xSdk.Shared;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Stores/Artifactory/ArtifactoryManager.Upload.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Stores/Artifactory/ArtifactoryManager.Upload.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //using RestSharp;
 //using System.Dynamic;
 //using System.Net;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Stores/Artifactory/ArtifactoryManager.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Stores/Artifactory/ArtifactoryManager.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //using xSdk.Data;
 //using Microsoft.Extensions.Logging;
 //using RestSharp;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Stores/Artifactory/ArtifactoryResolver.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Stores/Artifactory/ArtifactoryResolver.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using NuGet.Versioning;
 using Sewer56.Update.Packaging.Structures;
 

--- a/think-tank/libs/xSdk.Extensions.Package/src/Stores/Artifactory/ArtifactoryStore.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Stores/Artifactory/ArtifactoryStore.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //using Microsoft.Extensions.Logging;
 //using NuGet.Versioning;
 //using System.Text;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Stores/Cache/CacheManager.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Stores/Cache/CacheManager.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.IO;
 using System.Security.Permissions;
 using System.Text.Json;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Stores/Cache/CacheResolver.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Stores/Cache/CacheResolver.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Logging;
 using NuGet.Versioning;
 using Sewer56.Update.Packaging.Structures;

--- a/think-tank/libs/xSdk.Extensions.Package/src/Stores/Cache/CacheStore.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/Stores/Cache/CacheStore.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //using Microsoft.Extensions.Logging;
 //using System.Text;
 //using System.Text.Json;

--- a/think-tank/libs/xSdk.Extensions.Package/src/UpdateService.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/UpdateService.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Sewer56.Update;
 using Sewer56.Update.Packaging.Extractors;
 using Sewer56.Update.Packaging.Structures;

--- a/think-tank/libs/xSdk.Extensions.Package/src/UpdateServiceBuilder.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/UpdateServiceBuilder.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace xSdk.Extensions.Package
 {
     internal class UpdateServiceBuilder(IServiceProvider provider) : IUpdateServiceBuilder

--- a/think-tank/libs/xSdk.Extensions.Package/src/UpdateServiceBuilderExtensions.cs
+++ b/think-tank/libs/xSdk.Extensions.Package/src/UpdateServiceBuilderExtensions.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Roland Breitschaft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.DependencyInjection;
 using xSdk.Extensions.Package.Providers.GitHub;
 using xSdk.Extensions.Package.Providers.Local;


### PR DESCRIPTION
Add Apache License 2.0 headers to source files for compliance and update the .NET version from 9.0 to 10.0 in the README to reflect current project requirements.