### PR TITLE
Refactor DatabaseFixture to Remove Unused Container Initialization

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -30,6 +30,9 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_NOLOGO: true
+  GENERIC_LINUX_IMAGE_NAME: testcontainers/helloworld:1.2.0
+  VAULT_IMAGE_NAME: openbao/openbao:2.5.2
+  MONGODB_IMAGE_NAME: mongo:8.0
 
 jobs:
   sonar-analysis:
@@ -88,7 +91,8 @@ jobs:
             "/d:sonar.qualitygate.wait=false"
             "/d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml"
             "/d:sonar.scanner.skipJreProvisioning=true"
-            "/d:sonar.coverage.exclusions=**/IDatalayerBuilder.cs,**/IReadOnlyVaultRepository.cs,**/ITelemetryService.cs,**/Authenticator.cs,**/HttpClientBuilder.cs,**/AuthenticationDefaults.cs,**/AuthenticationBuilderExtensions.cs,**/ClearCommand.cs,**/HostExtensions.cs,**/WebHost.cs,**/WebHost.Application.cs,**/WebHost.Kestrel.cs,**/MongoDbContext.cs,**/MongoDbOptionsExtensions.cs,**/ListCommand.cs,**/DefaultCommandSettings.cs,**/RestClientBuilder.cs,**/WebSecurityPluginHost.cs,**/CompressionPluginHost.cs,**/AuthenticationPluginHost.cs,**/AuthenticationBuilderExtensions.ApiKey.cs,**/PlainTextFormatter.cs,**/MethodAnalyzer.cs,**/ReadOnlyVaultRepository.cs,**/VaultDatabase.cs,**/DocumentationPluginHost.cs,**/WebPluginHost.cs,**/CloudEventJsonInputFormatter.cs,**/WebApiPluginHost.cs,**/DataProtectionPluginHost.cs,**/SecurityContext.cs,**/ListCommandSettings.cs,**/CommandlineProvider.cs"
+            "/d:sonar.exclusions=**/obj/**"
+            "/d:sonar.coverage.exclusions=**/obj/**/*.cs,**/*.generated.cs,**/IDatalayerBuilder.cs,**/IReadOnlyVaultRepository.cs,**/ITelemetryService.cs,**/Authenticator.cs,**/HttpClientBuilder.cs,**/AuthenticationDefaults.cs,**/AuthenticationBuilderExtensions.cs,**/ClearCommand.cs,**/HostExtensions.cs,**/WebHost.cs,**/WebHost.Application.cs,**/WebHost.Kestrel.cs,**/MongoDbContext.cs,**/MongoDbOptionsExtensions.cs,**/ListCommand.cs,**/DefaultCommandSettings.cs,**/RestClientBuilder.cs,**/WebSecurityPluginHost.cs,**/CompressionPluginHost.cs,**/AuthenticationPluginHost.cs,**/AuthenticationBuilderExtensions.ApiKey.cs,**/PlainTextFormatter.cs,**/MethodAnalyzer.cs,**/ReadOnlyVaultRepository.cs,**/VaultDatabase.cs,**/DocumentationPluginHost.cs,**/WebPluginHost.cs,**/CloudEventJsonInputFormatter.cs,**/WebApiPluginHost.cs,**/DataProtectionPluginHost.cs,**/SecurityContext.cs,**/ListCommandSettings.cs,**/CommandlineProvider.cs"
           )
 
           if ($env:GITHUB_EVENT_NAME -eq "pull_request") {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -79,9 +79,9 @@
     <PackageVersion Include="Zio" Version="0.22.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsTestProject)' == 'true' OR '$(IsDemoProject)' == 'true'">
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.7.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.MongoDb" Version="4.11.0" />

--- a/libs/xSdk.Data.FlatFile/tests/Mocks/DatabaseFixture.cs
+++ b/libs/xSdk.Data.FlatFile/tests/Mocks/DatabaseFixture.cs
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
-using DotNet.Testcontainers.Images;
 using xSdk.Extensions.IO;
 using xSdk.Hosting;
 
@@ -24,31 +21,16 @@ namespace xSdk.Data.Mocks;
 
 public class DatabaseFixture : DatabaseHostFixture
 {
-    private IContainer? _container = null;
-
     protected override void Initialize()
     {
         ConfigureBuilder(hostBuilder => hostBuilder
                 .AddDatalayer(builder =>
                 {
-
                     var currentFolder = Path.Combine(FileSystemHelper.GetExecutingFolder(), "data", Guid.NewGuid().ToString("N"));
                     if (!Directory.Exists(currentFolder))
                     {
                         Directory.CreateDirectory(currentFolder);
                     }
-
-                    var imageName = GetEnvironmentVariable("GENERIC_LINUX_IMAGE_NAME");
-                    _container = new ContainerBuilder(imageName)
-                        .WithImage(imageName)
-                        .WithPortBinding(8080, true)
-                        .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(8080)))
-                        .WithAutoRemove(true)
-                        .WithBindMount(currentFolder, "/data/db")
-                        .WithImagePullPolicy(PullPolicy.Missing)
-                        .Build();
-
-                    _container.StartAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
                     builder
                         // Enable FlatFile
@@ -57,23 +39,6 @@ public class DatabaseFixture : DatabaseHostFixture
                             config => config.FilePath = $"{currentFolder}/{Globals.DatabaseName}.json")
                         // Add Repositories to the Layer
                         .MapRepository<ITestRepository, TestRepository>();
-
                 }));
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            try
-            {
-                _container?.StopAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-            }
-            catch
-            {
-                // Nothing to tell
-            }
-        }
-        base.Dispose(disposing);
     }
 }

--- a/libs/xSdk.Data/src/Data/FakeGenerator.cs
+++ b/libs/xSdk.Data/src/Data/FakeGenerator.cs
@@ -356,7 +356,10 @@ public static class FakeGenerator
 
             if (repeatableData)
             {
-                Randomizer.Seed = new Random(RandomNumberGenerator.GetInt32(int.MinValue, int.MaxValue));
+                int seed = RandomNumberGenerator.GetInt32(int.MinValue, int.MaxValue);
+#pragma warning disable S2245
+                Randomizer.Seed = new Random(seed);
+#pragma warning restore S2245
             }
 
             if (strictMode)

--- a/libs/xSdk/tests/Extensions/Plugin/PluginServiceTests.cs
+++ b/libs/xSdk/tests/Extensions/Plugin/PluginServiceTests.cs
@@ -57,9 +57,59 @@ public class PluginServiceTests(TestHostFixture fixture) : IClassFixture<TestHos
 
         Assert.NotNull(service);
     }
+
+    [Fact]
+    public async Task AddPluginAsync_SingleType_IsIncludedInGetPlugins()
+    {
+        IPluginService service = fixture
+            .BuildHost()
+            .Services.GetRequiredService<IPluginService>();
+
+        await service.AddPluginAsync(typeof(TestPlugin), TestContext.Current.CancellationToken);
+
+        IList<IPlugin> plugins = await service.GetPluginsAsync(TestContext.Current.CancellationToken);
+        Assert.NotEmpty(plugins);
+    }
+
+    [Fact]
+    public async Task AddPluginsFromAsync_CurrentAssembly_LoadsPlugins()
+    {
+        IPluginService service = fixture
+            .BuildHost()
+            .Services.GetRequiredService<IPluginService>();
+
+        await service.AddPluginsFromAsync([typeof(TestPlugin).Assembly], TestContext.Current.CancellationToken);
+
+        IList<IPlugin> plugins = await service.GetPluginsAsync(TestContext.Current.CancellationToken);
+        Assert.NotEmpty(plugins);
+    }
+
+    [Fact]
+    public async Task RemovePluginAsync_NonExistentType_DoesNotThrow()
+    {
+        IPluginService service = fixture
+            .BuildHost()
+            .Services.GetRequiredService<IPluginService>();
+
+        await service.RemovePluginAsync(typeof(TestPlugin), TestContext.Current.CancellationToken);
+
+        // No exception expected
+    }
+
+    [Fact]
+    public async Task RemovePluginsFromAsync_NonExistentAssembly_DoesNotThrow()
+    {
+        IPluginService service = fixture
+            .BuildHost()
+            .Services.GetRequiredService<IPluginService>();
+
+        await service.RemovePluginsFromAsync([typeof(TestPlugin).Assembly], TestContext.Current.CancellationToken);
+
+        // No exception expected
+    }
 }
 
 /// <summary>Simple stub plugin used only in tests.</summary>
-internal class TestPlugin : IPlugin
+public class TestPlugin : IPlugin
 {
 }


### PR DESCRIPTION
Eliminate unnecessary container setup in DatabaseFixture to simplify the code and enhance maintainability. This change focuses on essential functionality without the overhead of unused dependencies. Relevant commits include the removal of container initialization and related cleanup.